### PR TITLE
TeamOne (ME): reduced fifo depth in cce

### DIFF
--- a/bp_me/src/v/cce/bp_cce_top.v
+++ b/bp_me/src/v/cce/bp_cce_top.v
@@ -138,10 +138,14 @@ module bp_cce_top
   logic                                          mem_data_cmd_v_from_cce;
   logic                                          mem_data_cmd_ready_to_cce;
 
+  localparam data_fifo_depth_lp = 1; // These fifos are very wide
+  localparam  cmd_fifo_depth_lp = 1; // These fifos are less wide
+
   // Inbound LCE to CCE
-  bsg_two_fifo
+  bsg_fifo_1r1w_small
     #(.width_p(bp_lce_cce_req_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.els_p(cmd_fifo_depth_lp) // can be as low as 1
       )
     lce_cce_req_fifo
      (.clk_i(clk_i)
@@ -154,10 +158,11 @@ module bp_cce_top
       ,.yumi_i(lce_req_yumi_from_cce)
       );
 
-  bsg_two_fifo
+  bsg_fifo_1r1w_small
     #(.width_p(bp_lce_cce_resp_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
-      )
+      ,.els_p(`BSG_MAX(cmd_fifo_depth_lp, 2)) // MUST BE AT LEAST 2!
+     )
     lce_cce_resp_fifo
      (.clk_i(clk_i)
       ,.reset_i(reset_i)
@@ -169,9 +174,10 @@ module bp_cce_top
       ,.yumi_i(lce_resp_yumi_from_cce)
       );
 
-  bsg_two_fifo
+  bsg_fifo_1r1w_small
     #(.width_p(bp_lce_cce_data_resp_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.els_p(data_fifo_depth_lp) // can be as low as 1
       )
     lce_cce_data_resp_fifo
      (.clk_i(clk_i)
@@ -185,9 +191,10 @@ module bp_cce_top
       );
 
   // Inbound Mem to CCE
-  bsg_two_fifo
+  bsg_fifo_1r1w_small
     #(.width_p(bp_mem_cce_resp_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.els_p(cmd_fifo_depth_lp) // can be as low as 1
       )
     mem_cce_resp_fifo
      (.clk_i(clk_i)
@@ -200,9 +207,10 @@ module bp_cce_top
       ,.yumi_i(mem_resp_yumi_from_cce)
       );
 
-  bsg_two_fifo
+  bsg_fifo_1r1w_small
     #(.width_p(bp_mem_cce_data_resp_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.els_p(data_fifo_depth_lp) // can be as low as 1
       )
     mem_cce_data_resp_fifo
      (.clk_i(clk_i)
@@ -217,9 +225,10 @@ module bp_cce_top
 
 
   // Outbound CCE to Mem
-  bsg_two_fifo
+  bsg_fifo_1r1w_small
     #(.width_p(bp_cce_mem_cmd_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.els_p(cmd_fifo_depth_lp) // can be as low as 1
       )
     cce_mem_cmd_fifo
      (.clk_i(clk_i)
@@ -232,9 +241,10 @@ module bp_cce_top
       ,.yumi_i(mem_cmd_yumi_i)
       );
 
-  bsg_two_fifo
+  bsg_fifo_1r1w_small
     #(.width_p(bp_cce_mem_data_cmd_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.els_p(data_fifo_depth_lp) // can be as low as 1
       )
     cce_mem_data_cmd_fifo
      (.clk_i(clk_i)


### PR DESCRIPTION
**FIFOs in bp_cce_top have been reduced from two deep to one deep.** 

PPA results to memory end: 
- Power: reduced by 6.5%
- Performance: reduced by 1.3% _(IPC did not change)_
- Area: reduced by 3.8%