### PR TITLE
Size reduction of bp_me network mesh_router_buffered fifos

### DIFF
--- a/bp_me/src/v/network/bsg_fifo_1r1w_small.v
+++ b/bp_me/src/v/network/bsg_fifo_1r1w_small.v
@@ -1,0 +1,108 @@
+// bsg_fifo_1r1w_small
+//
+// bsg_fifo with 1 read and 1 write, using
+// 1-write 1-async-read register file implementation.
+//
+// used for smaller fifos.
+//
+// input handshake protocol (based on ready_THEN_valid_p parameter):
+//     valid-and-ready or
+//     ready-then-valid
+//
+// output protocol is valid-yumi (like typical fifo)
+//                    aka valid-then-ready
+//
+//
+
+module bsg_fifo_1r1w_small #( parameter width_p      = -1
+                            , parameter els_p        = -1
+                            , parameter ready_THEN_valid_p = 0
+                            )
+    ( input                clk_i
+    , input                reset_i
+
+    , input                v_i
+    , output               ready_o
+    , input [width_p-1:0]  data_i
+
+    , output               v_o
+    , output [width_p-1:0] data_o
+    , input                yumi_i
+    );
+
+   wire deque = yumi_i;
+   wire v_o_tmp;
+
+   assign v_o = v_o_tmp;
+
+   // vivado bug prohibits declaring wire inside of generate block
+   wire enque;
+   logic ready_lo;
+
+   if (ready_THEN_valid_p)
+     begin: rtv
+        assign enque = v_i;
+     end
+   else
+     begin: rav
+        assign enque = v_i & ready_lo;
+     end
+
+   localparam ptr_width_lp = `BSG_SAFE_CLOG2(els_p);
+
+   // one read pointer, one write pointer;
+   logic [ptr_width_lp-1:0] rptr_r, wptr_r;
+   logic                    full, empty;
+
+   bsg_fifo_tracker #(.els_p(els_p)
+                      ) ft
+     (.clk_i
+      ,.reset_i
+      ,.enq_i   (enque)
+      ,.deq_i   (deque)
+      ,.wptr_r_o(wptr_r)
+      ,.rptr_r_o(rptr_r)
+      ,.full_o  (full)
+      ,.empty_o (empty)
+      );
+
+   // async read
+   bsg_mem_1r1w #(.width_p (width_p)
+                  ,.els_p  (els_p  )
+		  // MBT: this should be zero
+                  ,.read_write_same_addr_p(0)
+                  ) mem_1r1w
+     (.w_clk_i   (clk_i  )
+      ,.w_reset_i(reset_i)
+      ,.w_v_i    (enque  )
+      ,.w_addr_i (wptr_r )
+      ,.w_data_i (data_i )
+      ,.r_v_i    (v_o_tmp)
+      ,.r_addr_i (rptr_r )
+      ,.r_data_o (data_o )
+      );
+
+   // during reset, we keep ready low
+   // even though fifo is empty
+
+   assign ready_lo = ~full & ~reset_i;
+   assign ready_o = ready_lo;
+   assign v_o_tmp = ~empty;
+
+   //synopsys translate_off
+   always_ff @ (posedge clk_i)
+     begin
+        if (ready_THEN_valid_p & full  & v_i    & ~reset_i)
+          $display("%m error: enque full fifo at time %t", $time);
+        if (empty & yumi_i & ~reset_i)
+          $display("%m error: deque empty fifo at time %t", $time);
+     end
+   //synopsys translate_on
+
+/*
+   always_ff @(negedge clk_i)
+     begin
+        $display("%m v_i=%x yumi_i=%x wptr=%b rptr=%b enque=%b full=%d empty=%d ready_o=%d",v_i,yumi_i,wptr_r, rptr_r, enque, full,empty,ready_o);
+     end
+ */
+endmodule

--- a/bp_me/src/v/network/bsg_mesh_router_buffered.v
+++ b/bp_me/src/v/network/bsg_mesh_router_buffered.v
@@ -1,0 +1,153 @@
+`include "bsg_noc_links.vh"
+
+module bsg_mesh_router_buffered #(width_p        = -1
+                                  ,x_cord_width_p = -1
+                                  ,y_cord_width_p = -1
+                                  ,debug_p       = 0
+                                  ,dirs_lp       = 5
+                                  ,stub_p        = { dirs_lp {1'b0}}  // SNEWP
+                                  ,allow_S_to_EW_p = 0
+                                  ,bsg_ready_and_link_sif_width_lp=`bsg_ready_and_link_sif_width(width_p)
+                                  // select whether to buffer the output
+                                  ,repeater_output_p = { dirs_lp {1'b0}}  // SNEWP
+                                  )
+   (
+    input clk_i
+    , input reset_i
+
+    , input  [dirs_lp-1:0][bsg_ready_and_link_sif_width_lp-1:0] link_i
+    , output [dirs_lp-1:0][bsg_ready_and_link_sif_width_lp-1:0] link_o
+
+    , input [x_cord_width_p-1:0] my_x_i
+    , input [y_cord_width_p-1:0] my_y_i
+    );
+
+   `declare_bsg_ready_and_link_sif_s(width_p,bsg_ready_and_link_sif_s);
+
+   bsg_ready_and_link_sif_s [dirs_lp-1:0] link_i_cast, link_o_cast;
+
+   assign link_i_cast =link_i;
+   assign link_o = link_o_cast;
+
+   logic [dirs_lp-1:0]              fifo_valid;
+   logic [dirs_lp-1:0][width_p-1:0] fifo_data;
+   logic [dirs_lp-1:0]              fifo_yumi;
+
+   genvar                           i;
+
+   //synopsys translate_off
+   if (debug_p)
+     for (i = 0; i < dirs_lp;i=i+1)
+       begin
+          always_ff @(negedge clk_i)
+            $display("%m x=%d y=%d SNEWP[%d] v_i=%b ready_o=%b v_o=%b ready_i=%b %b"
+                     ,my_x_i,my_y_i,i,link_i_cast[i].v,link_o_cast[i].ready_and_rev,
+                     link_o_cast[i].v,link_i_cast[i].ready_and_rev,link_i[i]);
+       end
+   //synopsys translate_on
+
+   for (i = 0; i < dirs_lp; i=i+1)
+     begin: rof
+        if (stub_p[i])
+          begin: fi
+             assign fifo_data   [i] = width_p ' (0);
+             assign fifo_valid  [i] = 1'b0;
+
+             // accept no data from outside of stubbed port
+             assign link_o_cast[i].ready_and_rev = 1'b0;
+
+             // synopsys translate_off
+             always @(negedge clk_i)
+               if (link_o_cast[i].v)
+                 $display("## warning %m: stubbed port %x received word %x",i,link_i_cast[i].data);
+             // synopsys translate_on
+          end
+        else
+          begin: fi
+            bsg_fifo_1r1w_small #( .width_p(width_p)
+                                  ,.els_p(1)
+                                 )
+              onefer
+              (.clk_i
+               ,.reset_i
+               
+               ,.v_i     (link_i_cast[i].v            )
+               ,.data_i  (link_i_cast[i].data         )
+               ,.ready_o (link_o_cast[i].ready_and_rev)
+
+               ,.v_o     (fifo_valid[i])
+               ,.data_o  (fifo_data [i])
+               ,.yumi_i  (fifo_yumi [i])
+               );
+          end
+     end
+
+   // router does not have symmetric interfaces;
+   // so we do not use bsg_ready_and_link_sif
+   // and manually convert. support for arrays
+   // of interfaces in systemverilog would
+   // fix this.
+
+   logic [dirs_lp-1:0]              valid_lo;
+   logic [dirs_lp-1:0][width_p-1:0] data_lo;
+   logic [dirs_lp-1:0]              ready_li;
+
+   for (i = 0; i < dirs_lp; i=i+1)
+     begin: rof2
+        assign link_o_cast[i].v    = valid_lo[i];
+
+        if (repeater_output_p[i] & ~stub_p[i])
+          begin : macro
+	     wire [width_p-1:0] tmp;
+
+            // synopsys translate_off
+            initial
+               begin
+                  $display("%m with buffers on %d",i);
+               end
+            // synopsys translate_on
+             bsg_inv #(.width_p(width_p),.vertical_p(i < 3)) data_lo_inv
+               (.i (data_lo[i]         )
+                ,.o(tmp)
+                );
+
+             bsg_inv #(.width_p(width_p),.vertical_p(i < 3)) data_lo_rep
+               (.i (tmp)
+                ,.o(link_o_cast[i].data)
+                );
+
+          end
+        else
+          assign link_o_cast[i].data = data_lo [i];
+
+        assign ready_li[i] = link_i_cast[i].ready_and_rev;
+     end
+
+   bsg_mesh_router #( .width_p      (width_p      )
+                      ,.x_cord_width_p(x_cord_width_p)
+                      ,.y_cord_width_p(y_cord_width_p)
+                      ,.debug_p      (debug_p      )
+                      ,.stub_p       (stub_p       )
+                      ,.allow_S_to_EW_p(allow_S_to_EW_p)
+                      ) bmr
+   (.clk_i
+    ,.reset_i
+    ,.v_i    (fifo_valid)
+    ,.data_i (fifo_data )
+    ,.yumi_o (fifo_yumi )
+
+    ,.v_o   (valid_lo)
+    ,.data_o(data_lo)
+
+    // this will be hardwired to 1 by inside of this module
+    // if port is stubbed
+
+    ,.ready_i(ready_li)
+
+    ,.my_x_i
+    ,.my_y_i
+    );
+
+
+endmodule
+

--- a/bp_me/syn/flist.vcs
+++ b/bp_me/syn/flist.vcs
@@ -66,7 +66,7 @@ $BSG_IP_CORES_DIR/bsg_misc/bsg_priority_encode_one_hot_out.v
 $BSG_IP_CORES_DIR/bsg_misc/bsg_round_robin_arb.v
 $BSG_IP_CORES_DIR/bsg_misc/bsg_scan.v
 $BSG_IP_CORES_DIR/bsg_noc/bsg_mesh_router.v
-$BSG_IP_CORES_DIR/bsg_noc/bsg_mesh_router_buffered.v
+#$BSG_IP_CORES_DIR/bsg_noc/bsg_mesh_router_buffered.v
 ## BE files
 # Common
 ## FE files
@@ -91,5 +91,6 @@ $BP_ME_DIR/src/v/cce/bp_cce_top.v
 # Network
 $BP_ME_DIR/src/v/network/bp_coherence_network.v
 $BP_ME_DIR/src/v/network/bp_coherence_network_channel.v
+$BP_ME_DIR/src/v/network/bsg_mesh_router_buffered.v
 ## TOP
 $BP_TOP_DIR/src/v/bp_multi_top.v


### PR DESCRIPTION
Throughout the network there are many fifos, many of which are nearly 600bits wide to accommodate the width of the cache lines in Black Parrot. Reducing the depth of these fifos has a massive improvement to power and area versus the baseline. Performance impacts were 0 at least in the design given in the lab. This may not be the case with other BP implementations in the future as congestion in the network caused by backpressure in these fifos could potentially impact performance negatively. The overall PPA could still improve if the benefits to power and area outweighed the performance degradation. 

Improvements vs Baseline

Area:     %13.1 and 315k um^2
Power:   %31.2 and .71e5uW
Performance had 0 change using the benchmarks provided.