### PR TITLE
PParrot BE critical path fixes

### DIFF
--- a/bp_be/src/include/bp_be_internal_if_defines.vh
+++ b/bp_be/src/include/bp_be_internal_if_defines.vh
@@ -63,7 +63,6 @@
   typedef struct packed                                                                            \
   {                                                                                                \
     logic                                   isd_v;                                                 \
-    logic[rv64_eaddr_width_gp-1:0]          isd_pc;                                                \
     logic                                   isd_irs1_v;                                            \
     logic                                   isd_frs1_v;                                            \
     logic[rv64_reg_addr_width_gp-1:0]       isd_rs1_addr;                                          \
@@ -78,10 +77,13 @@
     logic                                   int1_btaken;                                           \
                                                                                                    \
     logic                                   ex1_v;                                                 \
+    logic[rv64_eaddr_width_gp-1:0]          ex1_pc;                                                \
                                                                                                    \
-    // 5 is the number of stages in the pipeline                                                   \
-    // In fact, we don't need all of this dependency information, since some of the stages are     \
-    //    post-commit. However, for now we're passing all of it.                                   \
+    /*                                                                                             \
+     * 5 is the number of stages in the pipeline.                                                  \
+     * In fact, we don't need all of this dependency information, since some of the stages are     \
+     *    post-commit. However, for now we're passing all of it.                                   \
+     */                                                                                            \
     bp_be_dep_status_s[4:0]                 dep_status;                                            \
                                                                                                    \
     logic                                   mem3_v;                                                \

--- a/bp_be/src/include/bp_be_mmu_defines.vh
+++ b/bp_be/src/include/bp_be_mmu_defines.vh
@@ -4,8 +4,6 @@
 `define declare_bp_be_mmu_structs(vaddr_width_mp, sets_mp, block_size_in_bytes_mp)                 \
   typedef struct packed                                                                            \
   {                                                                                                \
-    logic [rv64_eaddr_width_gp-`bp_be_vtag_width(vaddr_width_mp, sets_mp, block_size_in_bytes_mp)-`BSG_SAFE_CLOG2(sets_mp*block_size_in_bytes_mp)-1:0] \
-                                                                               padding;            \
     logic [vaddr_width_mp-`BSG_SAFE_CLOG2(sets_mp*block_size_in_bytes_mp)-1:0] tag;                \
     logic [`BSG_SAFE_CLOG2(sets_mp)-1:0]                                       index;              \
     logic [`BSG_SAFE_CLOG2(block_size_in_bytes_mp)-1:0]                        offset;             \
@@ -13,15 +11,15 @@
                                                                                                    \
   typedef struct packed                                                                            \
   {                                                                                                \
-    bp_be_fu_op_s                     mem_op;                                                      \
-    bp_be_mmu_vaddr_s                 vaddr;                                                       \
-    logic[rv64_reg_data_width_gp-1:0] data;                                                        \
+    bp_be_fu_op_s                      mem_op;                                                     \
+    logic [vaddr_width_mp-1:0]         vaddr;                                                      \
+    logic [rv64_reg_data_width_gp-1:0] data;                                                       \
   }  bp_be_mmu_cmd_s;                                                                              \
                                                                                                    \
   typedef struct packed                                                                            \
   {                                                                                                \
-    logic[rv64_reg_data_width_gp-1:0] data;                                                        \
-    bp_be_exception_s                 exception;                                                   \
+    logic [rv64_reg_data_width_gp-1:0] data;                                                       \
+    bp_be_exception_s                  exception;                                                  \
   }  bp_be_mmu_resp_s;                                                                             \
 
 
@@ -31,8 +29,14 @@
 `define bp_be_ptag_width(paddr_width_mp, sets_mp, block_size_in_bytes_mp)                          \
   (paddr_width_mp-`BSG_SAFE_CLOG2(sets_mp*block_size_in_bytes_mp))
 
-`define bp_be_mmu_cmd_width                                                                        \
-  (`bp_be_fu_op_width + rv64_eaddr_width_gp + rv64_reg_data_width_gp)
+`define bp_be_mmu_vaddr_width(vaddr_width_p, sets_mp, block_size_in_bytes_mp)                      \
+  (`bp_be_vtag_width(vaddr_width_mp, sets_mp, block_size_in_bytes_mp)                              \
+   + `BSG_SAFE_CLOG2(sets_mp)                                                                      \
+   + `BSG_SAFE_CLOG2(block_size_in_bytes_mp)                                                       \
+   )
+
+`define bp_be_mmu_cmd_width(vaddr_width_mp)                                                        \
+  (`bp_be_fu_op_width + vaddr_width_mp + rv64_reg_data_width_gp)
 
 `define bp_be_mmu_resp_width                                                                       \
   (rv64_reg_data_width_gp + `bp_be_exception_width)

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -374,11 +374,11 @@ bp_be_pipe_mem
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
 
+   ,.kill_v_i(|exc_stage_r[0] | chk_poison_ex1_i) 
    ,.decode_i(calc_stage_r[dispatch_point_lp].decode)
    ,.rs1_i(calc_stage_r[dispatch_point_lp].instr_operands.rs1)
    ,.rs2_i(calc_stage_r[dispatch_point_lp].instr_operands.rs2)
    ,.imm_i(calc_stage_r[dispatch_point_lp].instr_operands.imm)
-   ,.exc_i(exc_stage_n[dispatch_point_lp+1])
 
    ,.mmu_cmd_o(mmu_cmd)
    ,.mmu_cmd_v_o(mmu_cmd_v_o)

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -70,7 +70,7 @@ module bp_be_calculator_top
    , localparam issue_pkt_width_lp      = `bp_be_issue_pkt_width(branch_metadata_fwd_width_p)
    , localparam calc_status_width_lp    = `bp_be_calc_status_width(branch_metadata_fwd_width_p)
    , localparam exception_width_lp      = `bp_be_exception_width
-   , localparam mmu_cmd_width_lp        = `bp_be_mmu_cmd_width
+   , localparam mmu_cmd_width_lp        = `bp_be_mmu_cmd_width(vaddr_width_p)
    , localparam mmu_resp_width_lp       = `bp_be_mmu_resp_width
    , localparam pipe_stage_reg_width_lp = `bp_be_pipe_stage_reg_width(branch_metadata_fwd_width_p)
    , localparam calc_result_width_lp    = `bp_be_calc_result_width(branch_metadata_fwd_width_p)
@@ -106,8 +106,8 @@ module bp_be_calculator_top
    
   , input                                chk_dispatch_v_i
   , input                                chk_roll_i
-  , input                                chk_poison_ex_i
-  , input                                chk_poison_isd_i
+  , input                                chk_poison_ex1_i
+  , input                                chk_poison_ex2_i
    
   , output [calc_status_width_lp-1:0]    calc_status_o
    
@@ -124,9 +124,6 @@ module bp_be_calculator_top
   , output [pipe_stage_reg_width_lp-1:0] cmt_trace_stage_reg_o
   , output [calc_result_width_lp-1:0]    cmt_trace_result_o
   , output [exception_width_lp-1:0]      cmt_trace_exc_o
-
-  // STD: TODO -- remove synth hack and find real solution
-  ,output [`bp_be_fu_op_width-1:0] decoded_fu_op_o
   );
 
 // Declare parameterizable structs
@@ -170,7 +167,8 @@ logic illegal_instr_isd, cache_miss_mem3;
 // Pipeline stage registers
 bp_be_pipe_stage_reg_s [pipe_stage_els_lp-1:0] calc_stage_r, calc_stage_n;
 bp_be_calc_result_s    [pipe_stage_els_lp-1:0] comp_stage_r, comp_stage_n;
-bp_be_exception_s      [pipe_stage_els_lp-1:0]  exc_stage_r , exc_stage_n;
+bp_be_exception_s      [pipe_stage_els_lp-1:0] exc_stage_r;
+bp_be_exception_s      [pipe_stage_els_lp  :0] exc_stage_n;
 
 bp_be_calc_result_s nop_calc_result;
 bp_be_calc_result_s int_calc_result; 
@@ -184,11 +182,8 @@ logic [pipe_stage_els_lp-1:1]                        comp_stage_n_slice_fwb_v;
 logic [pipe_stage_els_lp-1:1][reg_addr_width_lp-1:0] comp_stage_n_slice_rd_addr;
 logic [pipe_stage_els_lp-1:1][reg_data_width_lp-1:0] comp_stage_n_slice_rd;
 
-// STD: TODO -- remove synth hack and find real solution
-assign decoded_fu_op_o = decoded.fu_op;
-
 // Handshakes
-assign issue_pkt_ready_o = (chk_dispatch_v_i | ~issue_pkt_v_r) & ~chk_roll_i & ~chk_poison_isd_i;
+assign issue_pkt_ready_o = (chk_dispatch_v_i | ~issue_pkt_v_r) & ~chk_roll_i & ~chk_poison_ex1_i;
 
 // Module instantiations
 // Register files
@@ -352,7 +347,7 @@ bp_be_pipe_int
    ,.rs1_i(calc_stage_r[dispatch_point_lp].instr_operands.rs1)
    ,.rs2_i(calc_stage_r[dispatch_point_lp].instr_operands.rs2)
    ,.imm_i(calc_stage_r[dispatch_point_lp].instr_operands.imm)
-   ,.exc_i(exc_stage_r[dispatch_point_lp])
+   ,.exc_i(exc_stage_n[dispatch_point_lp+1])
 
    ,.mhartid_i(proc_cfg.mhartid)
 
@@ -369,7 +364,7 @@ bp_be_pipe_mul
    ,.decode_i(calc_stage_r[dispatch_point_lp].decode)
    ,.rs1_i(calc_stage_r[dispatch_point_lp].instr_operands.rs1)
    ,.rs2_i(calc_stage_r[dispatch_point_lp].instr_operands.rs2)
-   ,.exc_i(exc_stage_r[dispatch_point_lp])
+   ,.exc_i(exc_stage_n[dispatch_point_lp+1])
 
    ,.result_o(mul_calc_result.result)
    );
@@ -386,7 +381,7 @@ bp_be_pipe_mem
    ,.rs1_i(calc_stage_r[dispatch_point_lp].instr_operands.rs1)
    ,.rs2_i(calc_stage_r[dispatch_point_lp].instr_operands.rs2)
    ,.imm_i(calc_stage_r[dispatch_point_lp].instr_operands.imm)
-   ,.exc_i(exc_stage_r[dispatch_point_lp])
+   ,.exc_i(exc_stage_n[dispatch_point_lp+1])
 
    ,.mmu_cmd_o(mmu_cmd)
    ,.mmu_cmd_v_o(mmu_cmd_v_o)
@@ -409,7 +404,7 @@ bp_be_pipe_fp
    ,.decode_i(calc_stage_r[dispatch_point_lp].decode)
    ,.rs1_i(calc_stage_r[dispatch_point_lp].instr_operands.rs1)
    ,.rs2_i(calc_stage_r[dispatch_point_lp].instr_operands.rs2)
-   ,.exc_i(exc_stage_r[dispatch_point_lp])
+   ,.exc_i(exc_stage_n[dispatch_point_lp+1])
 
    ,.result_o(fp_calc_result.result)
    );
@@ -460,7 +455,7 @@ bsg_dff
    ) 
  exc_stage_reg
   (.clk_i(clk_i)
-   ,.data_i(exc_stage_n)
+   ,.data_i(exc_stage_n[0+:pipe_stage_els_lp])
    ,.data_o(exc_stage_r)
    );
 
@@ -476,7 +471,6 @@ always_comb
 
     // Calculator status ISD stage
     calc_status.isd_v                    = issue_pkt_v_r;
-    calc_status.isd_pc                   = issue_pkt_r.instr_metadata.pc;
     calc_status.isd_irs1_v               = issue_pkt_r.irs1_v;
     calc_status.isd_frs1_v               = issue_pkt_r.frs1_v;
     calc_status.isd_rs1_addr             = issue_pkt_r.rs1_addr;
@@ -485,46 +479,42 @@ always_comb
     calc_status.isd_rs2_addr             = issue_pkt_r.rs2_addr;
 
     // Calculator status EX1 information
-    calc_status.int1_v                   = calc_stage_r[0].decode.pipe_int_v 
-                                           & ~|exc_stage_r[0];
+    calc_status.int1_v                   = calc_stage_r[0].decode.pipe_int_v;
     calc_status.int1_br_tgt              = int_calc_result.br_tgt;
     calc_status.int1_branch_metadata_fwd = calc_stage_r[0].instr_metadata.branch_metadata_fwd;
     calc_status.int1_btaken              = (calc_stage_r[0].decode.br_v & int_calc_result.result[0])
                                            | calc_stage_r[0].decode.jmp_v;
     calc_status.int1_br_or_jmp           = calc_stage_r[0].decode.br_v 
                                            | calc_stage_r[0].decode.jmp_v;
-    calc_status.ex1_v                    = calc_stage_r[0].decode.instr_v
-                                           & ~|exc_stage_r[0];
+    calc_status.ex1_v                    = calc_stage_r[0].decode.instr_v;
+    calc_status.ex1_pc                   = calc_stage_r[0].instr_metadata.pc;
 
     // Dependency information for pipelines
     for (integer i = 0; i < pipe_stage_els_lp; i++) 
       begin : dep_status
         calc_status.dep_status[i].int_iwb_v = calc_stage_r[i].decode.pipe_int_v 
-                                              & ~|exc_stage_r[i] 
+                                              & ~|exc_stage_n[i+1] 
                                               & calc_stage_r[i].decode.irf_w_v;
         calc_status.dep_status[i].mul_iwb_v = calc_stage_r[i].decode.pipe_mul_v 
-                                              & ~|exc_stage_r[i] 
+                                              & ~|exc_stage_n[i+1] 
                                               & calc_stage_r[i].decode.irf_w_v;
         calc_status.dep_status[i].mem_iwb_v = calc_stage_r[i].decode.pipe_mem_v 
-                                              & ~|exc_stage_r[i] 
+                                              & ~|exc_stage_n[i+1] 
                                               & calc_stage_r[i].decode.irf_w_v;
         calc_status.dep_status[i].mem_fwb_v = calc_stage_r[i].decode.pipe_mem_v 
-                                              & ~|exc_stage_r[i] 
+                                              & ~|exc_stage_n[i+1] 
                                               & calc_stage_r[i].decode.frf_w_v;
         calc_status.dep_status[i].fp_fwb_v  = calc_stage_r[i].decode.pipe_fp_v  
-                                              & ~|exc_stage_r[i] 
+                                              & ~|exc_stage_n[i+1] 
                                               & calc_stage_r[i].decode.frf_w_v;
         calc_status.dep_status[i].rd_addr     = calc_stage_r[i].decode.rd_addr;
       end
 
     // Additional commit point information
-    calc_status.mem3_v            = calc_stage_r[2].decode.pipe_mem_v & ~|exc_stage_r[2];
+    calc_status.mem3_v            = calc_stage_r[2].decode.pipe_mem_v & ~|exc_stage_n[3];
     calc_status.mem3_pc           = calc_stage_r[2].instr_metadata.pc;
-    calc_status.mem3_cache_miss_v = cache_miss_mem3
-                                    & (calc_stage_r[2].decode.dcache_r_v
-                                       | calc_stage_r[2].decode.dcache_w_v
-                                       )
-                                    & ~|exc_stage_r[2];
+    // We don't want cache_miss itself to trigger the exception invalidation
+    calc_status.mem3_cache_miss_v = cache_miss_mem3 & ~|exc_stage_r[2]; 
     calc_status.mem3_exception_v  = 1'b0; 
     calc_status.mem3_ret_v        = calc_stage_r[2].decode.ret_v;
     calc_status.instr_cmt_v       = calc_stage_r[2].decode.instr_v & ~exc_stage_n[3].roll_v;
@@ -532,12 +522,15 @@ always_comb
     // Slicing the completion pipe for Forwarding information
     for (integer i = 1;i < pipe_stage_els_lp; i++) 
       begin : comp_stage_slice
-        comp_stage_n_slice_iwb_v[i]   = calc_stage_r[i-1].decode.irf_w_v & ~|exc_stage_r[i-1]; 
-        comp_stage_n_slice_fwb_v[i]   = calc_stage_r[i-1].decode.frf_w_v & ~|exc_stage_r[i-1]; 
+        comp_stage_n_slice_iwb_v[i]   = calc_stage_r[i-1].decode.irf_w_v & ~|exc_stage_n[i]; 
+        comp_stage_n_slice_fwb_v[i]   = calc_stage_r[i-1].decode.frf_w_v & ~|exc_stage_n[i]; 
         comp_stage_n_slice_rd_addr[i] = calc_stage_r[i-1].decode.rd_addr;
         comp_stage_n_slice_rd[i]      = comp_stage_n[i].result;
       end
+  end
 
+always_comb 
+  begin
     // Exception aggregation
     for (integer i = 0; i < pipe_stage_els_lp; i++) 
       begin : exc_stage
@@ -545,15 +538,13 @@ always_comb
         exc_stage_n[i] = (i == 0) ? '0 : exc_stage_r[i-1];
       end
         // If there are new exceptions, add them to the list
-        exc_stage_n[0].poison_v        = chk_poison_isd_i;
         exc_stage_n[0].roll_v          = chk_roll_i;
         exc_stage_n[0].illegal_instr_v = illegal_instr_isd;
-        exc_stage_n[1].poison_v        = exc_stage_r[0].poison_v | chk_poison_ex_i;
+        exc_stage_n[1].poison_v        = exc_stage_r[0].poison_v | chk_poison_ex1_i;
         exc_stage_n[1].roll_v          = exc_stage_r[0].roll_v   | chk_roll_i;
-        exc_stage_n[2].poison_v        = exc_stage_r[1].poison_v | chk_poison_ex_i;
+        exc_stage_n[2].poison_v        = exc_stage_r[1].poison_v | chk_poison_ex2_i;
         exc_stage_n[2].roll_v          = exc_stage_r[1].roll_v   | chk_roll_i;
         exc_stage_n[3].cache_miss_v    = cache_miss_mem3;
-        exc_stage_n[3].roll_v          = exc_stage_r[2].roll_v   | chk_roll_i;
   end
 
 // Commit tracer

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -64,6 +64,8 @@ module bp_be_calculator_top
    , parameter num_lce_p                   = "inv"
    , parameter lce_sets_p                  = "inv"
    , parameter cce_block_size_in_bytes_p   = "inv"
+
+   , parameter load_to_use_forwarding_p = 1
    
    // Generated parameters
    , localparam proc_cfg_width_lp       = `bp_proc_cfg_width(core_els_p, num_lce_p)
@@ -534,10 +536,13 @@ always_comb
     // Slicing the completion pipe for Forwarding information
     for (integer i = 1;i < pipe_stage_els_lp; i++) 
       begin : comp_stage_slice
-        comp_stage_n_slice_iwb_v[i]   = calc_stage_r[i-1].decode.irf_w_v & ~|exc_stage_n[i]; 
-        comp_stage_n_slice_fwb_v[i]   = calc_stage_r[i-1].decode.frf_w_v & ~|exc_stage_n[i]; 
+        comp_stage_n_slice_iwb_v[i]   = calc_stage_r[i-1].decode.irf_w_v & ~|exc_stage_r[i-1]; 
+        comp_stage_n_slice_fwb_v[i]   = calc_stage_r[i-1].decode.frf_w_v & ~|exc_stage_r[i-1]; 
         comp_stage_n_slice_rd_addr[i] = calc_stage_r[i-1].decode.rd_addr;
-        comp_stage_n_slice_rd[i]      = comp_stage_n[i].result;
+
+          comp_stage_n_slice_rd[i]    = comp_stage_n[i].result;
+        if ((load_to_use_forwarding_p == 0))
+          comp_stage_n_slice_rd[3]    = comp_stage_r[2].result;
       end
   end
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v
@@ -39,11 +39,6 @@ module bp_be_instr_decoder
    )
   (input [instr_width_lp-1:0]     instr_i
 
-   // Various sources of nop
-   , input                        fe_nop_v_i
-   , input                        be_nop_v_i
-   , input                        me_nop_v_i
-
    , output [decode_width_lp-1:0] decode_o
    , output                       illegal_instr_o
    );
@@ -61,7 +56,7 @@ assign illegal_instr_o = illegal_instr;
 always_comb 
   begin
     // Set decoded defaults
-    // NOPs
+    // NOPs are set after bypassing for critical path reasons
     decode.fe_nop_v      = '0; 
     decode.be_nop_v      = '0; 
     decode.me_nop_v      = '0; 
@@ -249,12 +244,9 @@ always_comb
     endcase
 
     /* If NOP or illegal instruction, dispatch the instruction directly to the completion pipe */
-    if (fe_nop_v_i | be_nop_v_i | me_nop_v_i | illegal_instr) 
+    if (illegal_instr) 
       begin
         decode             = '0;
-        decode.fe_nop_v    = fe_nop_v_i;
-        decode.be_nop_v    = be_nop_v_i;
-        decode.me_nop_v    = me_nop_v_i;
         decode.pipe_comp_v = 1'b1;
       end 
     else 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
@@ -49,7 +49,7 @@ module bp_be_pipe_mem
    // Generated parameters
    , localparam decode_width_lp    = `bp_be_decode_width
    , localparam exception_width_lp = `bp_be_exception_width
-   , localparam mmu_cmd_width_lp   = `bp_be_mmu_cmd_width
+   , localparam mmu_cmd_width_lp   = `bp_be_mmu_cmd_width(vaddr_width_p)
    , localparam mmu_resp_width_lp  = `bp_be_mmu_resp_width
 
    // From RISC-V specifications
@@ -96,13 +96,15 @@ wire unused1 = reset_i;
 wire unused2 = mmu_cmd_ready_i;
 wire unused3 = mmu_resp_v_i;
 
+
+
 // Module instantiations
 assign mmu_cmd_v_o    = (decode.dcache_r_v | decode.dcache_w_v) & ~|exc;
 always_comb 
   begin
     mmu_cmd.mem_op = decode.fu_op;
     mmu_cmd.data   = rs2_i;
-    mmu_cmd.vaddr  = rs1_i + imm_i;
+    mmu_cmd.vaddr  = (rs1_i + imm_i[0+:vaddr_width_p]);
   end 
 
 // Output results of memory op

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
@@ -58,11 +58,11 @@ module bp_be_pipe_mem
   (input                            clk_i
    , input                          reset_i
 
+   , input                          kill_v_i
    , input [decode_width_lp-1:0]    decode_i
    , input [reg_data_width_lp-1:0]  rs1_i
    , input [reg_data_width_lp-1:0]  rs2_i
    , input [reg_data_width_lp-1:0]  imm_i
-   , input [exception_width_lp-1:0] exc_i
 
    , output [mmu_cmd_width_lp-1:0]  mmu_cmd_o
    , output                         mmu_cmd_v_o
@@ -86,7 +86,6 @@ bp_be_mmu_cmd_s   mmu_cmd;
 bp_be_mmu_resp_s  mmu_resp;
 
 assign decode    = decode_i;
-assign exc       = exc_i;
 assign mmu_cmd_o = mmu_cmd;
 assign mmu_resp  = mmu_resp_i;
 
@@ -99,7 +98,7 @@ wire unused3 = mmu_resp_v_i;
 
 
 // Module instantiations
-assign mmu_cmd_v_o    = (decode.dcache_r_v | decode.dcache_w_v) & ~|exc;
+assign mmu_cmd_v_o    = (decode.dcache_r_v | decode.dcache_w_v) & ~kill_v_i;
 always_comb 
   begin
     mmu_cmd.mem_op = decode.fu_op;

--- a/bp_be/src/v/bp_be_checker/bp_be_checker_top.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_checker_top.v
@@ -114,8 +114,8 @@ module bp_be_checker_top
    // Checker pipeline control information
    , output                           chk_dispatch_v_o
    , output                           chk_roll_o
-   , output                           chk_poison_isd_o
-   , output                           chk_poison_ex_o
+   , output                           chk_poison_ex1_o
+   , output                           chk_poison_ex2_o
    );
 
 // Declare parameterizable structures
@@ -167,8 +167,8 @@ bp_be_detector
 
    ,.chk_dispatch_v_o(chk_dispatch_v_o)
    ,.chk_roll_o(chk_roll_o)
-   ,.chk_poison_isd_o(chk_poison_isd_o)
-   ,.chk_poison_ex_o(chk_poison_ex_o)
+   ,.chk_poison_ex1_o(chk_poison_ex1_o)
+   ,.chk_poison_ex2_o(chk_poison_ex2_o)
    );
 
 bp_be_scheduler 

--- a/bp_be/src/v/bp_be_checker/bp_be_checker_top.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_checker_top.v
@@ -66,6 +66,8 @@ module bp_be_checker_top
    , parameter asid_width_p                = "inv"
    , parameter branch_metadata_fwd_width_p = "inv"
 
+   , parameter load_to_use_forwarding_p = 1
+
    // Generated parameters
    , localparam calc_status_width_lp = `bp_be_calc_status_width(branch_metadata_fwd_width_p)
    , localparam fe_queue_width_lp    = `bp_fe_queue_width(vaddr_width_p
@@ -156,6 +158,7 @@ bp_be_detector
    ,.paddr_width_p(paddr_width_p)
    ,.asid_width_p(asid_width_p)
    ,.branch_metadata_fwd_width_p(branch_metadata_fwd_width_p)
+   ,.load_to_use_forwarding_p(load_to_use_forwarding_p)
    ) 
  detector
   (.clk_i(clk_i)

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.v
@@ -160,12 +160,10 @@ assign chk_dispatch_v_o = ~(data_haz_v | struct_haz_v);
 assign chk_roll_o       = calc_status.mem3_cache_miss_v;
 assign chk_poison_ex1_o = reset_i 
                           | mispredict_v
-                          | calc_status.mem3_cache_miss_v 
                           | calc_status.mem3_exception_v 
                           | calc_status.mem3_ret_v;
 
 assign chk_poison_ex2_o  = reset_i
-                           | calc_status.mem3_cache_miss_v 
                            | calc_status.mem3_exception_v 
                            | calc_status.mem3_ret_v;
 

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.v
@@ -47,6 +47,8 @@ module bp_be_detector
    , parameter asid_width_p                = "inv"
    , parameter branch_metadata_fwd_width_p = "inv"
 
+   , parameter load_to_use_forwarding_p = 1
+
    // Generated parameters
    , localparam calc_status_width_lp = `bp_be_calc_status_width(branch_metadata_fwd_width_p)
    // From BE specifications
@@ -90,7 +92,7 @@ wire unused2 = reset_i;
 
 // Declare intermediate signals
 // Integer data hazards
-logic [1:0] irs1_data_haz_v , irs2_data_haz_v;
+logic [2:0] irs1_data_haz_v , irs2_data_haz_v;
 // Floating point data hazards
 logic [2:0] frs1_data_haz_v , frs2_data_haz_v;
 logic [2:0] rs1_match_vector, rs2_match_vector;
@@ -138,6 +140,20 @@ always_comb
                          & (dep_status[1].mem_fwb_v | dep_status[1].fp_fwb_v);
 
     // Detect float data hazards for IWB. Integer dependencies can be handled by forwarding
+    if (load_to_use_forwarding_p == 0)
+      begin
+        irs1_data_haz_v[2] = (calc_status.isd_irs1_v & rs1_match_vector[2])
+                             & (dep_status[2].mem_iwb_v);
+
+        irs2_data_haz_v[2] = (calc_status.isd_irs2_v & rs2_match_vector[2])
+                             & (dep_status[2].mem_iwb_v);
+      end
+    else
+      begin
+        irs1_data_haz_v[2] = '0;
+        irs2_data_haz_v[2] = '0;
+      end
+
     frs1_data_haz_v[2] = (calc_status.isd_frs1_v & rs1_match_vector[2])
                          & (dep_status[2].fp_fwb_v);
 

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.v
@@ -39,6 +39,7 @@
  */
 
 module bp_be_detector 
+ import bp_common_pkg::*;
  import bp_be_rv64_pkg::*;
  import bp_be_pkg::*;
  #(parameter vaddr_width_p                 = "inv"
@@ -66,8 +67,8 @@ module bp_be_detector
    // Pipeline control signals from the checker to the calculator
    , output                           chk_dispatch_v_o
    , output                           chk_roll_o
-   , output                           chk_poison_isd_o
-   , output                           chk_poison_ex_o
+   , output                           chk_poison_ex1_o
+   , output                           chk_poison_ex2_o
   );
 
 `declare_bp_be_internal_if_structs(vaddr_width_p
@@ -150,22 +151,22 @@ always_comb
     struct_haz_v = ~mmu_cmd_ready_i;
 
     // Detect misprediction
-    mispredict_v = (calc_status.isd_v & (calc_status.isd_pc != expected_npc_i));
+    mispredict_v = (calc_status.ex1_v & (calc_status.ex1_pc != expected_npc_i));
 
   end
 
 // Generate calculator control signals
 assign chk_dispatch_v_o = ~(data_haz_v | struct_haz_v);
 assign chk_roll_o       = calc_status.mem3_cache_miss_v;
-assign chk_poison_isd_o = reset_i 
-                       | mispredict_v
-                       | calc_status.mem3_cache_miss_v 
-                       | calc_status.mem3_exception_v 
-                       | calc_status.mem3_ret_v;
+assign chk_poison_ex1_o = reset_i 
+                          | mispredict_v
+                          | calc_status.mem3_cache_miss_v 
+                          | calc_status.mem3_exception_v 
+                          | calc_status.mem3_ret_v;
 
-assign chk_poison_ex_o  = reset_i
-                       | calc_status.mem3_cache_miss_v 
-                       | calc_status.mem3_exception_v 
-                       | calc_status.mem3_ret_v;
+assign chk_poison_ex2_o  = reset_i
+                           | calc_status.mem3_cache_miss_v 
+                           | calc_status.mem3_exception_v 
+                           | calc_status.mem3_ret_v;
 
 endmodule : bp_be_detector

--- a/bp_be/src/v/bp_be_mmu/bp_be_mmu_top.v
+++ b/bp_be/src/v/bp_be_mmu/bp_be_mmu_top.v
@@ -105,7 +105,7 @@ module bp_be_mmu_top
    , localparam lce_id_width_lp = `BSG_SAFE_CLOG2(num_lce_p)
 
    // MMU                                                              
-   , localparam mmu_cmd_width_lp  = `bp_be_mmu_cmd_width
+   , localparam mmu_cmd_width_lp  = `bp_be_mmu_cmd_width(vaddr_width_p)
    , localparam mmu_resp_width_lp = `bp_be_mmu_resp_width
    , localparam vtag_width_lp     = `bp_be_vtag_width(vaddr_width_p
                                                       , lce_sets_p
@@ -159,7 +159,7 @@ module bp_be_mmu_top
    , input                                 mmu_cmd_v_i
    , output                                mmu_cmd_ready_o
 
-   , input                                 chk_psn_ex_i
+   , input                                 chk_poison_ex_i
 
    , output [mmu_resp_width_lp-1:0]        mmu_resp_o
    , output                                mmu_resp_v_o
@@ -208,9 +208,14 @@ module bp_be_mmu_top
 // Cast input and output ports 
 bp_be_mmu_cmd_s        mmu_cmd;
 bp_be_mmu_resp_s       mmu_resp;
+bp_be_mmu_vaddr_s      mmu_cmd_vaddr;
 
 assign mmu_cmd    = mmu_cmd_i;
 assign mmu_resp_o = mmu_resp;
+
+// TODO: This struct is not working properly (mismatched widths in synth). Figure out why.
+//         This cast works, though
+assign mmu_cmd_vaddr = mmu_cmd.vaddr;
 
 /* Internal connections */
 logic tlb_miss;
@@ -226,7 +231,7 @@ assign unused0 = mmu_resp_ready_i;
 // Passthrough TLB conversion
 always_ff @(posedge clk_i) 
   begin
-    ptag_r <= mmu_cmd.vaddr.tag;
+    ptag_r <= ptag_width_lp'(mmu_cmd_vaddr.tag);
   end
 
 bp_be_dcache 
@@ -254,7 +259,7 @@ bp_be_dcache
     ,.ptag_i(ptag_r)
 
     ,.cache_miss_o(dcache_miss_v)
-    ,.poison_i(chk_psn_ex_i)
+    ,.poison_i(chk_poison_ex_i)
 
     // LCE-CCE interface
     ,.lce_req_o(lce_req_o)
@@ -291,7 +296,7 @@ bp_be_dcache
 always_comb 
   begin
     dcache_pkt.opcode      = bp_be_dcache_opcode_e'(mmu_cmd.mem_op);
-    dcache_pkt.page_offset = {mmu_cmd.vaddr.index, mmu_cmd.vaddr.offset};
+    dcache_pkt.page_offset = {mmu_cmd_vaddr.index, mmu_cmd_vaddr.offset};
     dcache_pkt.data        = mmu_cmd.data;
 
     mmu_resp.exception.cache_miss_v = dcache_miss_v;

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -86,6 +86,8 @@ module bp_be_top
 
    , parameter core_els_p                  = "inv"
 
+   , parameter load_to_use_forwarding_p    = 1
+
    // MMU parameters
    , parameter num_cce_p                   = "inv"
    , parameter num_lce_p                   = "inv"
@@ -230,6 +232,8 @@ bp_be_checker_top
    ,.paddr_width_p(paddr_width_p)
    ,.asid_width_p(asid_width_p)
    ,.branch_metadata_fwd_width_p(branch_metadata_fwd_width_p)
+
+   ,.load_to_use_forwarding_p(load_to_use_forwarding_p)
    )
  be_checker
   (.clk_i(clk_i)
@@ -265,6 +269,8 @@ bp_be_calculator_top
    ,.paddr_width_p(paddr_width_p)
    ,.asid_width_p(asid_width_p)
    ,.branch_metadata_fwd_width_p(branch_metadata_fwd_width_p)
+   
+   ,.load_to_use_forwarding_p(load_to_use_forwarding_p)
 
    ,.core_els_p(core_els_p)
    ,.num_lce_p(num_lce_p)

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -222,7 +222,7 @@ bp_be_exception_s      cmt_trace_exc;
 bp_be_pipe_stage_reg_s cmt_trace_stage_reg;
 bp_be_calc_result_s    cmt_trace_result;
 
-logic chk_dispatch_v, chk_psn_isd, chk_psn_ex, chk_roll, chk_instr_dequeue_v;
+logic chk_dispatch_v, chk_poison_ex1, chk_poison_ex2, chk_roll, chk_instr_dequeue_v;
 
 // Module instantiations
 bp_be_checker_top 
@@ -237,8 +237,8 @@ bp_be_checker_top
 
    ,.chk_dispatch_v_o(chk_dispatch_v)
    ,.chk_roll_o(chk_roll)
-   ,.chk_poison_isd_o(chk_psn_isd)
-   ,.chk_poison_ex_o(chk_psn_ex)
+   ,.chk_poison_ex1_o(chk_poison_ex1)
+   ,.chk_poison_ex2_o(chk_poison_ex2)
 
    ,.calc_status_i(calc_status)
    ,.mmu_cmd_ready_i(mmu_cmd_rdy)
@@ -259,16 +259,6 @@ bp_be_checker_top
    ,.issue_pkt_v_o(issue_pkt_v)
    ,.issue_pkt_ready_i(issue_pkt_rdy)
    );
-
-// STD: TODO -- remove synth hack and find real solution
-wire [`bp_be_fu_op_width-1:0] decoded_fu_op_n;
-reg  [`bp_be_fu_op_width-1:0] decoded_fu_op_r;
-
-// STD: TODO -- remove synth hack and find real solution
-always_ff @(posedge clk_i)
-  begin
-    decoded_fu_op_r <= decoded_fu_op_n;
-  end
 
 bp_be_calculator_top 
  #(.vaddr_width_p(vaddr_width_p)
@@ -292,8 +282,8 @@ bp_be_calculator_top
    ,.chk_dispatch_v_i(chk_dispatch_v)
 
    ,.chk_roll_i(chk_roll)
-   ,.chk_poison_ex_i(chk_psn_ex)
-   ,.chk_poison_isd_i(chk_psn_isd)
+   ,.chk_poison_ex1_i(chk_poison_ex1)
+   ,.chk_poison_ex2_i(chk_poison_ex2)
 
    ,.calc_status_o(calc_status)
 
@@ -310,13 +300,7 @@ bp_be_calculator_top
    ,.cmt_trace_stage_reg_o(cmt_trace_stage_reg_o)
    ,.cmt_trace_result_o(cmt_trace_result_o)
    ,.cmt_trace_exc_o(cmt_trace_exc_o)
-
-    // STD: TODO -- remove synth hack and find real solution
-   ,.decoded_fu_op_o(decoded_fu_op_n)
-    );
-
-// STD: TODO -- remove synth hack and find real solution
-localparam mmu_sub_width_lp = $bits(mmu_cmd)-`bp_be_fu_op_width;
+   );
 
 bp_be_mmu_top
  #(.vaddr_width_p(vaddr_width_p)
@@ -334,12 +318,11 @@ bp_be_mmu_top
    (.clk_i(clk_i)
     ,.reset_i(reset_i)
 
-    // STD: TODO -- remove synth hack and find real solution
-    ,.mmu_cmd_i({decoded_fu_op_r, mmu_cmd[mmu_sub_width_lp-1:0]})
+    ,.mmu_cmd_i(mmu_cmd)
     ,.mmu_cmd_v_i(mmu_cmd_v)
     ,.mmu_cmd_ready_o(mmu_cmd_rdy)
 
-    ,.chk_psn_ex_i(chk_psn_ex)
+    ,.chk_poison_ex_i(chk_poison_ex2)
 
     ,.mmu_resp_o(mmu_resp)
     ,.mmu_resp_v_o(mmu_resp_v)

--- a/bp_be/test/tb/bp_be_trace_demo/Makefile.frag
+++ b/bp_be/test/tb/bp_be_trace_demo/Makefile.frag
@@ -13,7 +13,7 @@ DUT_PARAMS=-pvalue+core_els_p=1                        \
            -pvalue+num_lce_p=1                         \
            -pvalue+lce_sets_p=64                       \
            -pvalue+cce_block_size_in_bytes_p=64        \
-           -pvalue+lce_assoc_p=8
+           -pvalue+lce_assoc_p=8                       \
 
 HDL_PARAMS=$(DUT_PARAMS) $(TB_PARAMS)
 


### PR DESCRIPTION
Original: Critical paths through npc_check, then through nop logic, then cache->cache path which was unnecessary because of cache miss poison logic.

Frequency: 400 MHz
Area: 1283284.900015

Median
IPC: 466
MIPS: 186.4 
Power: 1.1842e+05 uW
EPI: 635.3 pJ

Multiply
IPC: 488
MIPS: 195.2
Power: 1.1769e+05 uW
EPI: 602.9 pJ

Towers
IPC: 505
MIPS: 202
Power: 1.2628e+05 uW
EPI: 625.1 pJ


Vvadd:
IPC: 453
MIPS: 181.2
Power: 1.1553e+05 uW
 EPI: 637.6 pJ


———————————————
With fixes: critical path now through dcache->bypass paths->dispatch.  Additionally, a parameter (default off) is added to disable this load->use forwarding. Expect an IPC decrease if this parameter is enabled.

Frequency: 513 MHz
Area: 1287764.798082

Median
IPC: 454
Power: 1.1736e+05
MIPS: 232.9
EPI: 503.9


Multiply
IPC: 460
Power: 1.1724e+05
MIPS: 236.0
EPI: 496.8


Towers
IPC: 486
Power: 1.2545e+05
MIPS: 249.3
EPI: 503.2


Vvadd:
IPC: 443
Power: 1.1548e+05
MIPS: 227.3
EPI: 508.1


———————————————
Note: All results post-synthesis