### PR TITLE
Modifying PC gen logic for branch prediction

### DIFF
--- a/bp_fe/src/v/bp_fe_btb.v
+++ b/bp_fe/src/v/bp_fe_btb.v
@@ -6,102 +6,61 @@
  * targets. In order to save the logic sizes, the BTB is designed to have limited 
  * entries for storing the branch sites, branch target pairs. The implementation 
  * uses the bsg_mem_1rw_sync_synth RAM design.
- *
- * Notes:
- *   BTB writes are prioritized over BTB reads, since they come on redirections and therefore 
- *     the BTB read is most likely for an erroneous instruction, anyway.
- */
+*/
+
 module bp_fe_btb
- import bp_fe_pkg::*;
- import bp_be_rv64_pkg::*;
- #(parameter btb_idx_width_p = "inv"
-
-   , localparam btb_offset_width_lp = 2 // bottom 2 bits are unused without compressed branches
-                                        // TODO: Should be a parameterizable struct
-
-   // From RISC-V specifications
-   , localparam eaddr_width_lp = rv64_eaddr_width_gp
+ import bp_fe_pkg::*; 
+ #(parameter   bp_fe_pc_gen_btb_idx_width_lp=9
+   , parameter eaddr_width_p="inv"
+   , localparam els_lp=2**bp_fe_pc_gen_btb_idx_width_lp
    ) 
-  (input                         clk_i
-   , input                       reset_i 
+  (input                                       clk_i
+   , input                                     reset_i 
 
-   // Synchronous read
-   , input [eaddr_width_lp-1:0]  r_addr_i
-   , input                       r_v_i
-   , output [eaddr_width_lp-1:0] br_tgt_o
-   , output                      br_tgt_v_o
+   , input [bp_fe_pc_gen_btb_idx_width_lp-1:0] idx_w_i
+   , input [bp_fe_pc_gen_btb_idx_width_lp-1:0] idx_r_i
+   , input                                     r_v_i
+   , input                                     w_v_i
 
-   , input [eaddr_width_lp-1:0]  w_addr_i
-   , input                       w_v_i
-   , input [eaddr_width_lp-1:0]  br_tgt_i
+   , input [eaddr_width_p-1:0]                 branch_target_i
+   , output logic [eaddr_width_p-1:0]          branch_target_o
+
+   , output logic                              read_valid_o
    );
 
-localparam btb_tag_width_lp = rv64_eaddr_width_gp-btb_idx_width_p-btb_offset_width_lp;
-localparam btb_els_lp       = 2**btb_idx_width_p;
-
-logic [btb_tag_width_lp-1:0] tag_mem_li, tag_mem_lo;
-logic [btb_idx_width_p-1:0]  tag_mem_addr_li;
-logic                        tag_mem_v_lo;
-
-logic [eaddr_width_lp-1:0]   tgt_mem_li, tgt_mem_lo;
-logic [btb_idx_width_p-1:0]  tgt_mem_addr_li;
    
-logic [btb_tag_width_lp-1:0] w_tag_n, w_tag_r;
-logic [btb_tag_width_lp-1:0] r_tag_n, r_tag_r;
-logic                        r_v_r;
+logic [els_lp-1:0] valid;
 
-assign tag_mem_li = w_addr_i[btb_offset_width_lp+btb_idx_width_p+:btb_tag_width_lp];
-assign tag_mem_addr_li = w_v_i
-                         ? w_addr_i[btb_offset_width_lp+:btb_idx_width_p] 
-                         : r_addr_i[btb_offset_width_lp+:btb_idx_width_p];
-                                
-bsg_mem_1rw_sync
- #(.width_p(btb_tag_width_lp+1)
-   ,.els_p(btb_els_lp)
-   )
- tag_mem
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i)
- 
-   ,.v_i(addr_r_v_i | addr_w_v_i)
-   ,.w_i(addr_w_v_i)
-
-   ,.data_i({1'b1, tag_mem_li})
-   ,.addr_i(tag_mem_addr_li)
-     
-   ,.r_data_o({tag_mem_v_lo, tag_mem_lo})
-   );
-
-assign tgt_mem_li      = br_tgt_i;
-assign tgt_mem_addr_li = w_v_i 
-                         ? w_addr_i[btb_offset_width_lp+:btb_idx_width_p] 
-                         : r_addr_i[btb_offset_width_lp+:btb_idx_width_p];
-bsg_mem_1rw_sync
- #(.width_p(eaddr_width_lp)
-   ,.els_p(btb_els_lp)
-   ) 
- tgt_mem
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i)
-
-   ,.v_i(addr_r_v_i | addr_w_v_i)
-   ,.w_i(addr_w_v_i)
-
-   ,.data_i(tgt_mem_li)
-   ,.addr_i(tgt_mem_addr_li)
-   
-   ,.r_data_o(tgt_mem_lo)
-   );
-
-assign bt_tgt_o   = tgt_mem_lo;
-assign br_tgt_v_o = tag_mem_v_lo & r_v_r & (tag_mem_lo == r_tag_r);
-
-always_ff @(posedge clk_i)
+always_ff @(posedge clk_i) 
   begin
-      r_tag_r <= r_addr_i[btb_offset_width_lp+btb_idx_width_p+:btb_tag_width_lp];
-
-      // Read didn't actually happen if there was a write
-      r_v_r <= r_v_i & ~w_v_i;
+    if (reset_i) 
+      begin
+        valid <= '{default:'0};
+      end 
+    else if (w_v_i) 
+      begin
+        valid[idx_w_i] <= '1;
+      end
   end
+
+assign read_valid_o = valid[idx_r_i];
+
+bsg_mem_1r1w 
+ #(.width_p(eaddr_width_p)
+   ,.els_p(2**bp_fe_pc_gen_btb_idx_width_lp)
+   ,.addr_width_lp(bp_fe_pc_gen_btb_idx_width_lp)
+   ) 
+ bsg_mem_1rw_sync_synth_1 
+  (.w_clk_i(clk_i)
+   ,.w_reset_i(reset_i)
+
+   ,.w_v_i(w_v_i)
+   ,.w_addr_i(idx_w_i)
+   ,.w_data_i(branch_target_i)
+   
+   ,.r_v_i(r_v_i)
+   ,.r_addr_i(idx_r_i)
+   ,.r_data_o(branch_target_o)
+   );
 
 endmodule

--- a/bp_fe/src/v/bp_fe_btb.v
+++ b/bp_fe/src/v/bp_fe_btb.v
@@ -6,61 +6,102 @@
  * targets. In order to save the logic sizes, the BTB is designed to have limited 
  * entries for storing the branch sites, branch target pairs. The implementation 
  * uses the bsg_mem_1rw_sync_synth RAM design.
-*/
-
+ *
+ * Notes:
+ *   BTB writes are prioritized over BTB reads, since they come on redirections and therefore 
+ *     the BTB read is most likely for an erroneous instruction, anyway.
+ */
 module bp_fe_btb
- import bp_fe_pkg::*; 
- #(parameter   bp_fe_pc_gen_btb_idx_width_lp=9
-   , parameter eaddr_width_p="inv"
-   , localparam els_lp=2**bp_fe_pc_gen_btb_idx_width_lp
+ import bp_fe_pkg::*;
+ import bp_be_rv64_pkg::*;
+ #(parameter btb_idx_width_p = "inv"
+
+   , localparam btb_offset_width_lp = 2 // bottom 2 bits are unused without compressed branches
+                                        // TODO: Should be a parameterizable struct
+
+   // From RISC-V specifications
+   , localparam eaddr_width_lp = rv64_eaddr_width_gp
    ) 
-  (input                                       clk_i
-   , input                                     reset_i 
+  (input                         clk_i
+   , input                       reset_i 
 
-   , input [bp_fe_pc_gen_btb_idx_width_lp-1:0] idx_w_i
-   , input [bp_fe_pc_gen_btb_idx_width_lp-1:0] idx_r_i
-   , input                                     r_v_i
-   , input                                     w_v_i
+   // Synchronous read
+   , input [eaddr_width_lp-1:0]  r_addr_i
+   , input                       r_v_i
+   , output [eaddr_width_lp-1:0] br_tgt_o
+   , output                      br_tgt_v_o
 
-   , input [eaddr_width_p-1:0]                 branch_target_i
-   , output logic [eaddr_width_p-1:0]          branch_target_o
-
-   , output logic                              read_valid_o
+   , input [eaddr_width_lp-1:0]  w_addr_i
+   , input                       w_v_i
+   , input [eaddr_width_lp-1:0]  br_tgt_i
    );
 
-   
-logic [els_lp-1:0] valid;
+localparam btb_tag_width_lp = rv64_eaddr_width_gp-btb_idx_width_p-btb_offset_width_lp;
+localparam btb_els_lp       = 2**btb_idx_width_p;
 
-always_ff @(posedge clk_i) 
+logic [btb_tag_width_lp-1:0] tag_mem_li, tag_mem_lo;
+logic [btb_idx_width_p-1:0]  tag_mem_addr_li;
+logic                        tag_mem_v_lo;
+
+logic [eaddr_width_lp-1:0]   tgt_mem_li, tgt_mem_lo;
+logic [btb_idx_width_p-1:0]  tgt_mem_addr_li;
+   
+logic [btb_tag_width_lp-1:0] w_tag_n, w_tag_r;
+logic [btb_tag_width_lp-1:0] r_tag_n, r_tag_r;
+logic                        r_v_r;
+
+assign tag_mem_li = w_addr_i[btb_offset_width_lp+btb_idx_width_p+:btb_tag_width_lp];
+assign tag_mem_addr_li = w_v_i
+                         ? w_addr_i[btb_offset_width_lp+:btb_idx_width_p] 
+                         : r_addr_i[btb_offset_width_lp+:btb_idx_width_p];
+                                
+bsg_mem_1rw_sync
+ #(.width_p(btb_tag_width_lp+1)
+   ,.els_p(btb_els_lp)
+   )
+ tag_mem
+  (.clk_i(clk_i)
+   ,.reset_i(reset_i)
+ 
+   ,.v_i(addr_r_v_i | addr_w_v_i)
+   ,.w_i(addr_w_v_i)
+
+   ,.data_i({1'b1, tag_mem_li})
+   ,.addr_i(tag_mem_addr_li)
+     
+   ,.r_data_o({tag_mem_v_lo, tag_mem_lo})
+   );
+
+assign tgt_mem_li      = br_tgt_i;
+assign tgt_mem_addr_li = w_v_i 
+                         ? w_addr_i[btb_offset_width_lp+:btb_idx_width_p] 
+                         : r_addr_i[btb_offset_width_lp+:btb_idx_width_p];
+bsg_mem_1rw_sync
+ #(.width_p(eaddr_width_lp)
+   ,.els_p(btb_els_lp)
+   ) 
+ tgt_mem
+  (.clk_i(clk_i)
+   ,.reset_i(reset_i)
+
+   ,.v_i(addr_r_v_i | addr_w_v_i)
+   ,.w_i(addr_w_v_i)
+
+   ,.data_i(tgt_mem_li)
+   ,.addr_i(tgt_mem_addr_li)
+   
+   ,.r_data_o(tgt_mem_lo)
+   );
+
+assign bt_tgt_o   = tgt_mem_lo;
+assign br_tgt_v_o = tag_mem_v_lo & r_v_r & (tag_mem_lo == r_tag_r);
+
+always_ff @(posedge clk_i)
   begin
-    if (reset_i) 
-      begin
-        valid <= '{default:'0};
-      end 
-    else if (w_v_i) 
-      begin
-        valid[idx_w_i] <= '1;
-      end
+      r_tag_r <= r_addr_i[btb_offset_width_lp+btb_idx_width_p+:btb_tag_width_lp];
+
+      // Read didn't actually happen if there was a write
+      r_v_r <= r_v_i & ~w_v_i;
   end
-
-assign read_valid_o = valid[idx_r_i];
-
-bsg_mem_1r1w 
- #(.width_p(eaddr_width_p)
-   ,.els_p(2**bp_fe_pc_gen_btb_idx_width_lp)
-   ,.addr_width_lp(bp_fe_pc_gen_btb_idx_width_lp)
-   ) 
- bsg_mem_1rw_sync_synth_1 
-  (.w_clk_i(clk_i)
-   ,.w_reset_i(reset_i)
-
-   ,.w_v_i(w_v_i)
-   ,.w_addr_i(idx_w_i)
-   ,.w_data_i(branch_target_i)
-   
-   ,.r_v_i(r_v_i)
-   ,.r_addr_i(idx_r_i)
-   ,.r_data_o(branch_target_o)
-   );
 
 endmodule


### PR DESCRIPTION
There was some complex logic in the pc gen module that meant that branch prediction wasn't working correctly. To remedy this, we made a couple modifications:
-Simplifying the pipelining within PC Gen by removing a register and prioritizing taking a redirect PC over icache miss PC. This is not strictly something we expect a PPA improvement from, but it makes it much easier to hook up a branch predictor.
-For now, the BHT/BTB are replaced with static prediction (forward not taken, backwards taken). 

We branched from the pparrot branch and compared PPA metrics post-synthesis:
Our minimum clock period is the same for both designs at 2.3 ns. The average instructions/s before optimization is 85,151,250 before optimization and 187,920,000 post optimization. **This is a 120% throughput improvement** which mostly comes from having an active branch predictor.

Because we commit a higher proportion of instructions, we also see improvements in energy efficiency. The average Avg J/Instruction is 1.35 * 10(-9) before optimization and 5.56 * 10^(-10) after our optimization. This is a **58% reduction in Avg J/Instruction**. 

Finally, we see an area improvement from 1,207,956 um^2 before optimization to 968,437 um^2 post optimization which is a **20% reduction in area**. This is due to eliminating the more complex branch prediction logic. Although we did simplify logic and remove registers within the PC gen module itself, this is probably small in proportion to removing memories for the BHT and BTB. Because the BHT and BTB were not being used properly before though, we do not sacrifice performance for this gain in area. 