### PR TITLE
Add clock gating to largest RAMs

### DIFF
--- a/bp_me/src/v/cce/bp_cce_dir.v
+++ b/bp_me/src/v/cce/bp_cce_dir.v
@@ -113,6 +113,7 @@ module bp_cce_dir
   bsg_mem_1rw_sync_mask_write_bit
     #(.width_p(way_group_width_lp)
       ,.els_p(num_way_groups_p)
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     wg_ram
      (

--- a/bp_me/syn/flist.vcs
+++ b/bp_me/syn/flist.vcs
@@ -31,6 +31,8 @@ $BP_BE_DIR/src/include/bp_be_dcache/bp_be_dcache_pkg.vh
 $BP_ME_DIR/src/include/v/bp_cce_pkg.v
 $BP_ME_DIR/src/include/v/bp_me_network_pkg.v
 ## bsg_ip_cores files
+$BSG_IP_CORES_DIR/bsg_misc/bsg_dlatch.v
+$BSG_IP_CORES_DIR/bsg_misc/bsg_clkgate_optional.v
 $BSG_IP_CORES_DIR/bsg_dataflow/bsg_fifo_1r1w_small.v
 $BSG_IP_CORES_DIR/bsg_dataflow/bsg_fifo_tracker.v
 $BSG_IP_CORES_DIR/bsg_dataflow/bsg_shift_reg.v

--- a/bp_me/test/common/bp_mem.v
+++ b/bp_me/test/common/bp_mem.v
@@ -72,6 +72,7 @@ module bp_mem
   bsg_mem_1rw_sync
     #(.width_p(block_size_in_bits_lp)
       ,.els_p(mem_els_p)
+      ,.enable_clock_gating_p(1'b1) // Gating enabled!
     ) mem
     (.clk_i(clk_i)
      ,.reset_i(reset_i)


### PR DESCRIPTION
# Adds clock gating to largest RAMs

Uses the new bsg_ip_cores branch that includes clock gated rams.
Clock gating added to L2 memory and CCE Directory.

PPA Analysis (post synth):
- Power: down 1.15 %
- Performance: down 1.90 %
- Area: down 0.03 %

Since the memory end will most likely not be the critical path, it will likely not be clocked at its max frequency. 