### PR TITLE
PPArrot: ME (Chase & Derek) Clock gating for network and large rams

### DIFF
--- a/bp_me/src/v/cce/bp_cce_dir.v
+++ b/bp_me/src/v/cce/bp_cce_dir.v
@@ -113,6 +113,7 @@ module bp_cce_dir
   bsg_mem_1rw_sync_mask_write_bit
     #(.width_p(way_group_width_lp)
       ,.els_p(num_way_groups_p)
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     wg_ram
      (

--- a/bp_me/src/v/cce/bp_cce_top.v
+++ b/bp_me/src/v/cce/bp_cce_top.v
@@ -142,6 +142,7 @@ module bp_cce_top
   bsg_two_fifo
     #(.width_p(bp_lce_cce_req_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     lce_cce_req_fifo
      (.clk_i(clk_i)
@@ -157,6 +158,7 @@ module bp_cce_top
   bsg_two_fifo
     #(.width_p(bp_lce_cce_resp_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     lce_cce_resp_fifo
      (.clk_i(clk_i)
@@ -172,6 +174,7 @@ module bp_cce_top
   bsg_two_fifo
     #(.width_p(bp_lce_cce_data_resp_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     lce_cce_data_resp_fifo
      (.clk_i(clk_i)
@@ -188,6 +191,7 @@ module bp_cce_top
   bsg_two_fifo
     #(.width_p(bp_mem_cce_resp_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     mem_cce_resp_fifo
      (.clk_i(clk_i)
@@ -203,6 +207,7 @@ module bp_cce_top
   bsg_two_fifo
     #(.width_p(bp_mem_cce_data_resp_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     mem_cce_data_resp_fifo
      (.clk_i(clk_i)
@@ -220,6 +225,7 @@ module bp_cce_top
   bsg_two_fifo
     #(.width_p(bp_cce_mem_cmd_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     cce_mem_cmd_fifo
      (.clk_i(clk_i)
@@ -235,6 +241,7 @@ module bp_cce_top
   bsg_two_fifo
     #(.width_p(bp_cce_mem_data_cmd_width_lp)
       ,.ready_THEN_valid_p(1) // ready-then-valid
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     cce_mem_data_cmd_fifo
      (.clk_i(clk_i)

--- a/bp_me/src/v/network/bp_coherence_network.v
+++ b/bp_me/src/v/network/bp_coherence_network.v
@@ -143,6 +143,7 @@ module bp_coherence_network
       ,.num_dst_p(num_lce_p)
       ,.debug_p(debug_p)
       ,.repeater_output_p(repeater_output_lp)
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     cce_lce_cmd_network
      (.clk_i(clk_i)
@@ -164,6 +165,7 @@ module bp_coherence_network
       ,.num_dst_p(num_lce_p)
       ,.debug_p(debug_p)
       ,.repeater_output_p(repeater_output_lp)
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     cce_lce_data_cmd_network
      (.clk_i(clk_i)
@@ -185,6 +187,7 @@ module bp_coherence_network
       ,.num_dst_p(num_cce_p)
       ,.debug_p(debug_p)
       ,.repeater_output_p(repeater_output_lp)
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     lce_cce_req_network
      (.clk_i(clk_i)
@@ -206,6 +209,7 @@ module bp_coherence_network
       ,.num_dst_p(num_cce_p)
       ,.debug_p(debug_p)
       ,.repeater_output_p(repeater_output_lp)
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     lce_cce_resp_network
      (.clk_i(clk_i)
@@ -227,6 +231,7 @@ module bp_coherence_network
       ,.num_dst_p(num_cce_p)
       ,.debug_p(debug_p)
       ,.repeater_output_p(repeater_output_lp)
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     lce_cce_data_resp_network
      (.clk_i(clk_i)
@@ -248,6 +253,7 @@ module bp_coherence_network
       ,.num_dst_p(num_lce_p)
       ,.debug_p(debug_p)
       ,.repeater_output_p(repeater_output_lp)
+      ,.enable_clock_gating_p(1'b1) // Gating enabled! 
       )
     lce_lce_tr_resp_network
      (.clk_i(clk_i)

--- a/bp_me/src/v/network/bp_coherence_network_channel.v
+++ b/bp_me/src/v/network/bp_coherence_network_channel.v
@@ -31,6 +31,7 @@ module bp_coherence_network_channel
   #(parameter packet_width_p        = "inv"
     , parameter num_src_p           = "inv"
     , parameter num_dst_p           = "inv"
+    , parameter enable_clock_gating_p = 1'b0 // Default to clock gating off
 
     // Default parameters
     , parameter debug_p             = 0
@@ -143,6 +144,7 @@ module bp_coherence_network_channel
             ,.allow_S_to_EW_p(1)
             ,.bsg_ready_and_link_sif_width_lp(bsg_ready_then_link_sif_width_lp)
             ,.repeater_output_p(repeater_output_p)
+            ,.enable_clock_gating_p(enable_clock_gating_p)
             )
           coherence_network_channel_node
            (.clk_i(clk_i)
@@ -168,6 +170,7 @@ module bp_coherence_network_channel
             ,.allow_S_to_EW_p(1)
             ,.bsg_ready_and_link_sif_width_lp(bsg_ready_then_link_sif_width_lp)
             ,.repeater_output_p(repeater_output_p)
+            ,.enable_clock_gating_p(enable_clock_gating_p)
             )
           coherence_network_channel_node
            (.clk_i(clk_i)
@@ -200,6 +203,7 @@ module bp_coherence_network_channel
             ,.allow_S_to_EW_p(1)
             ,.bsg_ready_and_link_sif_width_lp(bsg_ready_then_link_sif_width_lp)
             ,.repeater_output_p(repeater_output_p)
+            ,.enable_clock_gating_p(enable_clock_gating_p)
             )
           coherence_network_channel_node
            (.clk_i(clk_i)
@@ -230,6 +234,7 @@ module bp_coherence_network_channel
             ,.allow_S_to_EW_p(1)
             ,.bsg_ready_and_link_sif_width_lp(bsg_ready_then_link_sif_width_lp)
             ,.repeater_output_p(repeater_output_p)
+            ,.enable_clock_gating_p(enable_clock_gating_p)
             )
           coherence_network_channel_node
            (.clk_i(clk_i)
@@ -257,6 +262,7 @@ module bp_coherence_network_channel
             ,.allow_S_to_EW_p(1)
             ,.bsg_ready_and_link_sif_width_lp(bsg_ready_then_link_sif_width_lp)
             ,.repeater_output_p(repeater_output_p)
+            ,.enable_clock_gating_p(enable_clock_gating_p)
             )
           coherence_network_channel_node
            (.clk_i(clk_i)
@@ -289,6 +295,7 @@ module bp_coherence_network_channel
             ,.allow_S_to_EW_p(1)
             ,.bsg_ready_and_link_sif_width_lp(bsg_ready_then_link_sif_width_lp)
             ,.repeater_output_p(repeater_output_p)
+            ,.enable_clock_gating_p(enable_clock_gating_p)
             )
           coherence_network_channel_node
            (.clk_i(clk_i)
@@ -319,6 +326,7 @@ module bp_coherence_network_channel
             ,.allow_S_to_EW_p(1)
             ,.bsg_ready_and_link_sif_width_lp(bsg_ready_then_link_sif_width_lp)
             ,.repeater_output_p(repeater_output_p)
+            ,.enable_clock_gating_p(enable_clock_gating_p)
             )
           coherence_network_channel_node
            (.clk_i(clk_i)
@@ -354,6 +362,7 @@ module bp_coherence_network_channel
             ,.allow_S_to_EW_p(1)
             ,.bsg_ready_and_link_sif_width_lp(bsg_ready_then_link_sif_width_lp)
             ,.repeater_output_p(repeater_output_p)
+            ,.enable_clock_gating_p(enable_clock_gating_p)
             )
           coherence_network_channel_node
            (.clk_i(clk_i)

--- a/bp_me/syn/flist.vcs
+++ b/bp_me/syn/flist.vcs
@@ -31,6 +31,8 @@ $BP_BE_DIR/src/include/bp_be_dcache/bp_be_dcache_pkg.vh
 $BP_ME_DIR/src/include/v/bp_cce_pkg.v
 $BP_ME_DIR/src/include/v/bp_me_network_pkg.v
 ## bsg_ip_cores files
+$BSG_IP_CORES_DIR/bsg_misc/bsg_dlatch.v
+$BSG_IP_CORES_DIR/bsg_misc/bsg_clkgate_optional.v
 $BSG_IP_CORES_DIR/bsg_dataflow/bsg_fifo_1r1w_small.v
 $BSG_IP_CORES_DIR/bsg_dataflow/bsg_fifo_tracker.v
 $BSG_IP_CORES_DIR/bsg_dataflow/bsg_shift_reg.v

--- a/bp_me/test/common/bp_mem.v
+++ b/bp_me/test/common/bp_mem.v
@@ -72,6 +72,7 @@ module bp_mem
   bsg_mem_1rw_sync
     #(.width_p(block_size_in_bits_lp)
       ,.els_p(mem_els_p)
+      ,.enable_clock_gating_p(1'b1) // Gating enabled!
     ) mem
     (.clk_i(clk_i)
      ,.reset_i(reset_i)


### PR DESCRIPTION
# Added Clock Gating to most RAMs. 

Added clock gating to:
- L2 and CCE Directory
- FIFOs in Network
- FIFOs between CCE and L2

(Uses clock_gating branch of EE 477 bsg_ip_cores.)

**Results:**
Baseline:

Post Synth |   |  
-- | -- | --
Power p(J/I) | Performance M(I/s) | Area (cell only) (mm^2)
2,861.28 | 61.8 | 2.470


This branch: _percentages below are in comparison to baseline_

Post Synth |   |  
-- | -- | --
Power p(J/I) | Performance M(I/s) | Area (cell only) (mm^2)
573.65 | 60.1 | 2.473
-79.95 | -2.67 | 0.13

(Post PnR results in progress)

**Conclusion:**
Power down 80% post synth with small losses to performance and area.