### PR TITLE
add data gating in calculator/pipe_int

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -536,8 +536,8 @@ always_comb
     // Slicing the completion pipe for Forwarding information
     for (integer i = 1;i < pipe_stage_els_lp; i++) 
       begin : comp_stage_slice
-        comp_stage_n_slice_iwb_v[i]   = calc_stage_r[i-1].decode.irf_w_v & ~|exc_stage_r[i-1]; 
-        comp_stage_n_slice_fwb_v[i]   = calc_stage_r[i-1].decode.frf_w_v & ~|exc_stage_r[i-1]; 
+        comp_stage_n_slice_iwb_v[i]   = calc_stage_r[i-1].decode.irf_w_v & ~|exc_stage_r[i]; 
+        comp_stage_n_slice_fwb_v[i]   = calc_stage_r[i-1].decode.frf_w_v & ~|exc_stage_r[i]; 
         comp_stage_n_slice_rd_addr[i] = calc_stage_r[i-1].decode.rd_addr;
 
           comp_stage_n_slice_rd[i]    = comp_stage_n[i].result;

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -536,8 +536,8 @@ always_comb
     // Slicing the completion pipe for Forwarding information
     for (integer i = 1;i < pipe_stage_els_lp; i++) 
       begin : comp_stage_slice
-        comp_stage_n_slice_iwb_v[i]   = calc_stage_r[i-1].decode.irf_w_v & ~|exc_stage_r[i]; 
-        comp_stage_n_slice_fwb_v[i]   = calc_stage_r[i-1].decode.frf_w_v & ~|exc_stage_r[i]; 
+        comp_stage_n_slice_iwb_v[i]   = calc_stage_r[i-1].decode.irf_w_v & ~|exc_stage_n[i]; 
+        comp_stage_n_slice_fwb_v[i]   = calc_stage_r[i-1].decode.frf_w_v & ~|exc_stage_n[i]; 
         comp_stage_n_slice_rd_addr[i] = calc_stage_r[i-1].decode.rd_addr;
 
           comp_stage_n_slice_rd[i]    = comp_stage_n[i].result;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v
@@ -76,12 +76,15 @@ wire unused1 = reset_i;
 // Submodule connections
 logic [reg_data_width_lp-1:0] src1, src2, baddr, alu_result;
 logic [reg_data_width_lp-1:0] pc_plus4, mhartid;
+logic [reg_data_width_lp-1:0] src1_gated, src2_gated;
 
+assign src1_gated = {reg_data_width_lp{decode.pipe_int_v}} & src1;
+assign src2_gated = {reg_data_width_lp{decode.pipe_int_v}} & src2;
 // Perform the actual ALU computation
 bp_be_int_alu 
  alu
-  (.src1_i(src1)
-   ,.src2_i(src2)
+  (.src1_i(src1_gated)
+   ,.src2_i(src2_gated)
    ,.op_i(decode.fu_op)
    ,.opw_v_i(decode.opw_v)
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v
@@ -76,10 +76,25 @@ wire unused1 = reset_i;
 // Submodule connections
 logic [reg_data_width_lp-1:0] src1, src2, baddr, alu_result;
 logic [reg_data_width_lp-1:0] pc_plus4, mhartid;
-logic [reg_data_width_lp-1:0] src1_gated, src2_gated;
+logic [reg_data_width_lp-1:0] src1_r, src2_r, src1_gated, src2_gated;
 
-assign src1_gated = {reg_data_width_lp{decode.pipe_int_v}} & src1;
-assign src2_gated = {reg_data_width_lp{decode.pipe_int_v}} & src2;
+assign src1_gated = decode.pipe_int_v ? src1 : src1_r;
+assign src2_gated = decode.pipe_int_v ? src2 : src2_r;
+
+bsg_dff_en #(.width_p(reg_data_width_lp)) src1_dff (
+  .clk_i(clk_i)
+  ,.data_i(src1)
+  ,.en_i(decode.pipe_int_v)
+  ,.data_o(src1_r)
+  );
+
+bsg_dff_en #(.width_p(reg_data_width_lp)) src2_dff (
+  .clk_i(clk_i)
+  ,.data_i(src2)
+  ,.en_i(decode.pipe_int_v)
+  ,.data_o(src2_r)
+  );
+
 // Perform the actual ALU computation
 bp_be_int_alu 
  alu

--- a/bp_be/src/v/bp_be_mmu/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mmu/bp_be_dcache/bp_be_dcache.v
@@ -181,7 +181,21 @@ module bp_be_dcache
   logic byte_op_tl_r;
   logic [bp_page_offset_width_gp-1:0] page_offset_tl_r;
   logic [data_width_p-1:0] data_tl_r;
+  logic [paddr_width_p-1:0] paddr_tl;
+  logic [tag_width_lp-1:0] addr_tag_tl;
+  logic load_hit;
+  logic store_hit;
+  logic [way_id_width_lp-1:0] load_hit_way;
+  logic [way_id_width_lp-1:0] store_hit_way;
+  logic load_hit_bit_tl;
+  logic store_hit_bit_tl;
+  logic [way_id_width_lp-1:0] load_hit_way_tl;
+  logic [way_id_width_lp-1:0] store_hit_way_tl;
 
+
+   assign paddr_tl = {ptag_i, page_offset_tl_r};
+   
+  assign addr_tag_tl = paddr_tl[block_offset_width_lp+index_width_lp+:tag_width_lp]; 
   assign tl_we = v_i & ready_o & ~poison_i;
  
   always_ff @ (posedge clk_i) begin
@@ -277,15 +291,31 @@ module bp_be_dcache
   logic [index_width_lp-1:0] addr_index_tv;
   logic [word_offset_width_lp-1:0] addr_word_offset_tv;
 
+  logic [ways_p-1:0] load_hit_tv;
+  logic [ways_p-1:0] load_hit_tl;
+  logic [ways_p-1:0] store_hit_tv;
+  logic [ways_p-1:0] store_hit_tl;
+
   assign tv_we = v_tl_r & ~poison_i & ~tlb_miss_i;
 
   always_ff @ (posedge clk_i) begin
     if (reset_i) begin
       v_tv_r <= 1'b0;
+      store_hit_tv <= '0; 
+      load_hit_tv <= '0;
+      load_hit <= '0;
+      store_hit <= '0;
+      load_hit_way <= '0;
+      store_hit_way <= '0;
     end
     else begin
       v_tv_r <= tv_we;
-
+      store_hit_tv <= store_hit_tl; 
+      load_hit_tv <= load_hit_tl; 
+      load_hit <= load_hit_bit_tl;
+      store_hit <= store_hit_bit_tl;
+      load_hit_way <= load_hit_way_tl;
+      store_hit_way <= store_hit_way_tl;
       if (tv_we) begin
         load_op_tv_r <= load_op_tl_r;
         store_op_tv_r <= store_op_tl_r;
@@ -311,24 +341,20 @@ module bp_be_dcache
   assign addr_tag_tv = paddr_tv_r[block_offset_width_lp+index_width_lp+:tag_width_lp];
   assign addr_index_tv = paddr_tv_r[block_offset_width_lp+:index_width_lp];
   assign addr_word_offset_tv = paddr_tv_r[byte_offset_width_lp+:word_offset_width_lp];
-
+   
   // miss_detect
   //
-  logic [ways_p-1:0] load_hit_tv;
-  logic [ways_p-1:0] store_hit_tv;
+  logic [ways_p-1:0] way_hit_tl; 
   logic [ways_p-1:0] invalid_tv;
   logic load_miss_tv;
   logic store_miss_tv;
-  logic load_hit;
-  logic store_hit;
-  logic [way_id_width_lp-1:0] load_hit_way;
-  logic [way_id_width_lp-1:0] store_hit_way;
 
   for (genvar i = 0; i < ways_p; i++) begin
-    assign load_hit_tv[i] = (addr_tag_tv == tag_info_tv_r[i].tag)
-      & (tag_info_tv_r[i].coh_state != e_MESI_I);
-    assign store_hit_tv[i] = (addr_tag_tv == tag_info_tv_r[i].tag)
-      & (tag_info_tv_r[i].coh_state == e_MESI_E);
+    assign way_hit_tl[i] = addr_tag_tl == tag_mem_data_lo[i].tag; 
+    assign load_hit_tl[i] = way_hit_tl[i]
+      & (tag_mem_data_lo[i].coh_state != e_MESI_I);
+    assign store_hit_tl[i] = way_hit_tl[i]
+      & (tag_mem_data_lo[i].coh_state == e_MESI_E);
     assign invalid_tv[i] = (tag_info_tv_r[i].coh_state == e_MESI_I);
   end
 
@@ -337,9 +363,9 @@ module bp_be_dcache
       ,.lo_to_hi_p(1)
       )
     pe_load_hit
-    (.i(load_hit_tv)
-      ,.v_o(load_hit)
-      ,.addr_o(load_hit_way)
+    (.i(load_hit_tl)
+      ,.v_o(load_hit_bit_tl)
+      ,.addr_o(load_hit_way_tl)
       );
   
   bsg_priority_encode
@@ -347,9 +373,9 @@ module bp_be_dcache
       ,.lo_to_hi_p(1)
       )
     pe_store_hit
-    (.i(store_hit_tv)
-      ,.v_o(store_hit)
-      ,.addr_o(store_hit_way)
+    (.i(store_hit_tl)
+      ,.v_o(store_hit_bit_tl)
+      ,.addr_o(store_hit_way_tl)
       );
 
   assign load_miss_tv = ~load_hit & v_tv_r & load_op_tv_r;

--- a/bp_be/src/v/bp_be_mmu/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mmu/bp_be_dcache/bp_be_dcache.v
@@ -290,10 +290,7 @@ module bp_be_dcache
   logic [tag_width_lp-1:0] addr_tag_tv;
   logic [index_width_lp-1:0] addr_index_tv;
   logic [word_offset_width_lp-1:0] addr_word_offset_tv;
-
-  logic [ways_p-1:0] load_hit_tv_r;
   logic [ways_p-1:0] load_hit_tl;
-  logic [ways_p-1:0] store_hit_tv_r;
   logic [ways_p-1:0] store_hit_tl;
 
   assign tv_we = v_tl_r & ~poison_i & ~tlb_miss_i;
@@ -301,12 +298,6 @@ module bp_be_dcache
   always_ff @ (posedge clk_i) begin
     if (reset_i) begin
       v_tv_r <= 1'b0;
-      store_hit_tv_r <= '0; 
-      load_hit_tv_r <= '0;
-      load_hit_bit_r <= '0;
-      store_hit_bit_r <= '0;
-      load_hit_way_r <= '0;
-      store_hit_way_r <= '0;
     end
     else begin
       v_tv_r <= tv_we;
@@ -320,12 +311,8 @@ module bp_be_dcache
         byte_op_tv_r <= byte_op_tl_r;
         paddr_tv_r <= {ptag_i, page_offset_tl_r};
         tag_info_tv_r <= tag_mem_data_lo;
-        store_hit_tv_r <= store_hit_tl; 
-        load_hit_tv_r <= load_hit_tl; 
         load_hit_bit_r <= load_hit_bit_tl;
-        store_hit_bit_r <= store_hit_bit_tl;
         load_hit_way_r <= load_hit_way_tl;
-        store_hit_way_r <= store_hit_way_tl;
       end
 
       if (tv_we & load_op_tl_r) begin
@@ -333,6 +320,8 @@ module bp_be_dcache
       end
 
       if (tv_we & store_op_tl_r) begin
+        store_hit_way_r <= store_hit_way_tl;
+        store_hit_bit_r <= store_hit_bit_tl;	 
         data_tv_r <= data_tl_r;
       end
     end
@@ -914,11 +903,11 @@ module bp_be_dcache
   end
 
   always_ff @ (negedge clk_i) begin
-    if (v_tv_r) begin
-      assert($countones(load_hit_tv_r) <= 1)
-        else $error("multiple load hit: %b. id = %0d", load_hit_tv_r, lce_id_i);
-      assert($countones(store_hit_tv_r) <= 1)
-        else $error("multiple store hit: %b. id = %0d", store_hit_tv_r, lce_id_i);
+    if (tv_we) begin
+      assert($countones(load_hit_tl) <= 1)
+        else $error("multiple load hit: %b. id = %0d", load_hit_tl, lce_id_i);
+      assert($countones(store_hit_tl) <= 1)
+        else $error("multiple store hit: %b. id = %0d", store_hit_tl, lce_id_i);
     end
   end
 

--- a/bp_be/src/v/bp_be_mmu/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mmu/bp_be_dcache/bp_be_dcache.v
@@ -310,12 +310,6 @@ module bp_be_dcache
     end
     else begin
       v_tv_r <= tv_we;
-      store_hit_tv_r <= store_hit_tl; 
-      load_hit_tv_r <= load_hit_tl; 
-      load_hit_bit_r <= load_hit_bit_tl;
-      store_hit_bit_r <= store_hit_bit_tl;
-      load_hit_way_r <= load_hit_way_tl;
-      store_hit_way_r <= store_hit_way_tl;
       if (tv_we) begin
         load_op_tv_r <= load_op_tl_r;
         store_op_tv_r <= store_op_tl_r;
@@ -326,6 +320,12 @@ module bp_be_dcache
         byte_op_tv_r <= byte_op_tl_r;
         paddr_tv_r <= {ptag_i, page_offset_tl_r};
         tag_info_tv_r <= tag_mem_data_lo;
+        store_hit_tv_r <= store_hit_tl; 
+        load_hit_tv_r <= load_hit_tl; 
+        load_hit_bit_r <= load_hit_bit_tl;
+        store_hit_bit_r <= store_hit_bit_tl;
+        load_hit_way_r <= load_hit_way_tl;
+        store_hit_way_r <= store_hit_way_tl;
       end
 
       if (tv_we & load_op_tl_r) begin


### PR DESCRIPTION
Add data gating the input data of the integer pipeline:

In tower post synth test, we save 42% power decease in the pipeline, and 1.4% power decrease in bp top.
In multiply post synth test, we save 53% power decease in the pipeline, and 2.3% power decrease in bp top.
