### PR TITLE
clk gating on mems

### DIFF
--- a/bp_be/src/v/bp_be_mmu/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mmu/bp_be_dcache/bp_be_dcache.v
@@ -220,6 +220,7 @@ module bp_be_dcache
   bsg_mem_1rw_sync_mask_write_bit
     #(.width_p(tag_info_width_lp*ways_p)
       ,.els_p(sets_p)
+      ,.enable_clock_gating_p(1'b1)
     )
     tag_mem
       (.clk_i(clk_i)
@@ -245,6 +246,7 @@ module bp_be_dcache
     bsg_mem_1rw_sync_mask_write_byte
       #(.data_width_p(data_width_p)
         ,.els_p(sets_p*ways_p)
+        ,.enable_clock_gating_p(1'b1)
         )
       data_mem
         (.clk_i(clk_i)
@@ -458,6 +460,7 @@ module bp_be_dcache
   bsg_mem_1rw_sync_mask_write_bit
     #(.width_p(stat_info_width_lp)
       ,.els_p(sets_p)
+      ,.enable_clock_gating_p(1'b1)
       )
     stat_mem
       (.clk_i(clk_i)

--- a/bp_be/syn/flist.vcs
+++ b/bp_be/syn/flist.vcs
@@ -67,6 +67,8 @@ $BSG_IP_CORES_DIR/bsg_misc/bsg_round_robin_arb.v
 $BSG_IP_CORES_DIR/bsg_misc/bsg_scan.v
 $BSG_IP_CORES_DIR/bsg_noc/bsg_mesh_router.v
 $BSG_IP_CORES_DIR/bsg_noc/bsg_mesh_router_buffered.v
+$BSG_IP_CORES_DIR/bsg_misc/bsg_clkgate_optional.v
+$BSG_IP_CORES_DIR/bsg_misc/bsg_dlatch.v
 ## BE files
 $BP_BE_DIR/src/v/bp_be_top.v
 # Calculator


### PR DESCRIPTION
We tried to do clock gating on mems. The results show ~10% less in power.

clock speed: 351 Mhz -> 379 Mhz
area:1.316 mm^2 -> 1.311 mm^2
Power: 0.152 W->0.137 W
