### PR TITLE
Pparrot mittal tang dcache add param clkgate

### DIFF
--- a/bp_be/src/v/bp_be_mmu/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mmu/bp_be_dcache/bp_be_dcache.v
@@ -148,6 +148,9 @@ module bp_be_dcache
   bp_be_dcache_pkt_s dcache_pkt;
   assign dcache_pkt = dcache_pkt_i;
 
+  //enable clkgate? 1 = enable, 0 = disable
+  localparam enable_clkgate = 1'b1;
+
   logic load_op;
   logic store_op;
   logic signed_op;
@@ -220,6 +223,7 @@ module bp_be_dcache
   bsg_mem_1rw_sync_mask_write_bit
     #(.width_p(tag_info_width_lp*ways_p)
       ,.els_p(sets_p)
+      ,.enable_clock_gating_p(enable_clkgate)
     )
     tag_mem
       (.clk_i(clk_i)
@@ -245,6 +249,7 @@ module bp_be_dcache
     bsg_mem_1rw_sync_mask_write_byte
       #(.data_width_p(data_width_p)
         ,.els_p(sets_p*ways_p)
+        ,.enable_clock_gating_p(enable_clkgate)
         )
       data_mem
         (.clk_i(clk_i)
@@ -458,6 +463,7 @@ module bp_be_dcache
   bsg_mem_1rw_sync_mask_write_bit
     #(.width_p(stat_info_width_lp)
       ,.els_p(sets_p)
+      ,.enable_clock_gating_p(enable_clkgate)
       )
     stat_mem
       (.clk_i(clk_i)

--- a/bp_be/src/v/bp_be_mmu/bp_be_dcache/bp_be_dcache_lce.v
+++ b/bp_be/src/v/bp_be_mmu/bp_be_dcache/bp_be_dcache_lce.v
@@ -184,6 +184,8 @@ module bp_be_dcache_lce
   assign tag_mem_pkt_o = tag_mem_pkt;
   assign stat_mem_pkt_o = stat_mem_pkt;
 
+  //enable clockgate? 1 = enable, 0 = disable
+  localparam enable_clkgate = 1'b1;
 
   // LCE_CCE_req
   //
@@ -250,6 +252,7 @@ module bp_be_dcache_lce
   // this two_fifo is needed to convert from valid-yumi to valid-ready interface.
   bsg_two_fifo
     #(.width_p(cce_lce_cmd_width_lp)
+     ,.enable_clock_gating_p(enable_clkgate)
       )
     lce_cmd_fifo 
       (.clk_i(clk_i)
@@ -329,7 +332,9 @@ module bp_be_dcache_lce
 
   // this two_fifo is needed to convert from valid-yumi to valid-ready interface.
   bsg_two_fifo
-    #(.width_p(cce_lce_data_cmd_width_lp))
+    #(.width_p(cce_lce_data_cmd_width_lp)
+     ,.enable_clock_gating_p(enable_clkgate)
+     )
     lce_data_cmd_fifo
       (.clk_i(clk_i)
       ,.reset_i(reset_i)
@@ -377,7 +382,9 @@ module bp_be_dcache_lce
 
   // this two_fifo is needed to convert from valid-yumi to valid-ready interface.
   bsg_two_fifo
-    #(.width_p(lce_lce_tr_resp_width_lp))
+    #(.width_p(lce_lce_tr_resp_width_lp)
+     ,.enable_clock_gating_p(enable_clkgate)
+     )
     lce_tr_resp_in_fifo
       (.clk_i(clk_i)
       ,.reset_i(reset_i)


### PR DESCRIPTION
Added clkgating parameter in dcache.v and dcache_lce.v in bp_be_mmu.
The following data is collected at constraint = 3.0ns and uncertainty of 0.5ns
This branch is not built upon Dan's becriticalpathfixes branch. The power saving makes sense. However, I expect the area to increase by a bit in dcache due to the clock gating logic and no change in performance. Though dcache's area did increase, the calculator's and checker's area decreased (which I'm not 100% what happened just yet). Performance also improved, though only by a little.

![image](https://user-images.githubusercontent.com/48067062/54175080-b06f6280-4446-11e9-9efb-e557f9a92e16.png)


