### PR TITLE
ICache clock gating - lce fifos and cache memory banks

### DIFF
--- a/bp_fe/src/v/bp_fe_icache.v
+++ b/bp_fe/src/v/bp_fe_icache.v
@@ -200,6 +200,7 @@ module icache
   bsg_mem_1rw_sync_mask_write_bit #(
     .width_p(bp_fe_icache_tag_set_width_lp)
     ,.els_p(lce_sets_p)
+    ,.enable_clock_gating_p(1'b1)
   ) tag_mem (
     .clk_i(clk_i)
     ,.reset_i(reset_i)
@@ -235,6 +236,7 @@ module icache
     bsg_mem_1rw_sync_mask_write_byte #(
       .data_width_p(data_width_p)
       ,.els_p(lce_sets_p*ways_p) // same number of blocks and ways
+      ,.enable_clock_gating_p(1'b1)
     ) data_mem_bank (
       .clk_i(clk_i)
       ,.reset_i(reset_i)
@@ -327,6 +329,7 @@ module icache
   bsg_mem_1rw_sync_mask_write_bit #(
     .width_p(bp_fe_icache_metadata_width_lp)
     ,.els_p(lce_sets_p)
+    ,.enable_clock_gating_p(1'b1)
   ) metadata_mem (
     .clk_i(clk_i)
     ,.reset_i(reset_i)

--- a/bp_fe/src/v/bp_fe_lce.v
+++ b/bp_fe/src/v/bp_fe_lce.v
@@ -228,6 +228,7 @@ module bp_fe_lce
 
   bsg_two_fifo #(
     .width_p(bp_cce_lce_cmd_width_lp)
+    ,.enable_clock_gating_p(1'b1)
   ) lce_cmd_fifo (
     .clk_i(clk_i)
     ,.reset_i(reset_i)
@@ -304,6 +305,7 @@ module bp_fe_lce
 
   bsg_two_fifo #(
     .width_p(bp_cce_lce_data_cmd_width_lp)
+    ,.enable_clock_gating_p(1'b1)
   ) lce_data_cmd_fifo (
     .clk_i(clk_i)
     ,.reset_i(reset_i)
@@ -347,8 +349,11 @@ module bp_fe_lce
   bp_lce_lce_tr_resp_s lce_tr_resp_in_fifo_data_lo;
   logic lce_tr_resp_in_fifo_yumi_li;
 
+  
+
   bsg_two_fifo #(
     .width_p(bp_lce_lce_tr_resp_width_lp)
+    ,.enable_clock_gating_p(1'b1)
   ) lce_tr_resp_in_fifo (
     .clk_i(clk_i)
     ,.reset_i(reset_i)

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -47,6 +47,8 @@ $BSG_IP_CORES_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
 $BSG_IP_CORES_DIR/bsg_mem/bsg_mem_1rw_sync_synth.v
 $BSG_IP_CORES_DIR/bsg_mem/bsg_mem_2r1w_sync.v
 $BSG_IP_CORES_DIR/bsg_mem/bsg_mem_2r1w_sync_synth.v
+$BSG_IP_CORES_DIR/bsg_misc/bsg_clkgate_optional.v
+$BSG_IP_CORES_DIR/bsg_misc/bsg_dlatch.v
 $BSG_IP_CORES_DIR/bsg_misc/bsg_adder_ripple_carry.v
 $BSG_IP_CORES_DIR/bsg_misc/bsg_circular_ptr.v
 $BSG_IP_CORES_DIR/bsg_misc/bsg_counter_clear_up.v


### PR DESCRIPTION
We aimed to reduce power consumed in the icache section of the front end

From viewing initial power reports we noticed that in some test cases (such as towers) power consumed by the icache region was around 70% of total power in the front end. Some of the power contributions were suspicious, like how the LCE consummed over 35% of overall power in the front end. Specifically the two deep async fifos. What really surprised us is all the fifos from the lce (3 of them) used the same amount of power even though only one of them was used most of the time!

We clock gated these fifos and also the data mem, tag mem, and meta data mem (although these had low impact which makes sense since they are accessed almost all the time, minus during cache misses, and we made sure that their valid signals made sense). Overall, the largest energy reduction was from clock gating the async fifos in the lce. For example, in towers, the trace_in fifo contributed 12.5% alone to the overall to the power consumed in the front end (and it was never used in these test cases) and now it is 0.7% overall contribution to power. 

We go into more detailed analysis in our report, below is the comparison of PPA before and after. Let us know if you have any questions! :^)

![image](https://user-images.githubusercontent.com/46538370/54235592-ec0e3900-44e7-11e9-9b52-9d15e6cf6cc4.png)
