### PR TITLE
PC_Gen static branch prediction

### DIFF
--- a/bp_fe/src/v/bp_fe_branch_predictor.v
+++ b/bp_fe/src/v/bp_fe_branch_predictor.v
@@ -52,24 +52,7 @@ assign branch_metadata_o     = {pc_fwd_i[btb_indx_width_p-1:0]
 
 
    
-bp_fe_bht 
- #(.bht_indx_width_p(bht_indx_width_p)
-   ) 
- bht_1
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i)
-   ,.en_i(1'b1)
-        
-   ,.idx_r_i(pc_queue_i[bht_indx_width_p-1:0])
-   ,.idx_w_i(branch_metadata_i.bht_indx)
-     
-   ,.r_v_i(r_v_i)
-   ,.w_v_i(w_v_i)
-     
-   ,.correct_i(attaboy_i)
-   ,.predict_o(predict)
-   );
-
+assign predict = ([pc_o[4:0] < pc_queue_i[4:0]);
     
 bp_fe_btb
  #(.bp_fe_pc_gen_btb_idx_width_lp(btb_indx_width_p)

--- a/bp_fe/src/v/bp_fe_branch_predictor.v
+++ b/bp_fe/src/v/bp_fe_branch_predictor.v
@@ -52,7 +52,7 @@ assign branch_metadata_o     = {pc_fwd_i[btb_indx_width_p-1:0]
 
 
    
-assign predict = ([pc_o[4:0] < pc_queue_i[4:0]);
+assign predict = (pc_o[4:0] < pc_queue_i[4:0]);
     
 bp_fe_btb
  #(.bp_fe_pc_gen_btb_idx_width_lp(btb_indx_width_p)


### PR DESCRIPTION
Deleted the BHT and added static branch prediction based on the lowest five bits of the pc and the next pc from the btb. This assumes two things. One, forward branches are not taken and backward branches are taken. Two, code usually does not branch more than five to ten instructions away, so we could assume all of the high order bits are the same, and we only need to compare about the lowest five bits.

Instr/S:
--------
Baseline:         206.28 MInstr/S
Optimization: 211.40 MInstr/S
Change:          5.12 MInstr/S or 2.45% increase

J/Instr
--------
Baseline:         369.65 pJ/Instr
Optimization: 353.86 pJ/Instr
Change:          -15.79 pJ/Instr or 4.48% decrease

Area
--------
Baseline:         1333895 um^2
Optimization: 1330278 um^2
Change:          -3617 um^2 or 0.272% decrease

As you can see every aspect of PPA was better with my optimization so there is no reason not to adopt it  except for maybe me not following the coding guidelines. Particularly where I just wrote [4:0] instead of using one of the parameters, but honestly I wasn't sure which one to use :)