### PR TITLE
RTLchanges

### DIFF
--- a/bp_be/src/v/bp_be_checker/bp_be_detector.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.v
@@ -157,15 +157,17 @@ always_comb
 // Generate calculator control signals
 assign chk_dispatch_v_o = ~(data_haz_v | struct_haz_v);
 assign chk_roll_o       = calc_status.mem3_cache_miss_v;
-assign chk_poison_isd_o = reset_i 
+/*assign chk_poison_isd_o = reset_i 
                        | mispredict_v
                        | calc_status.mem3_cache_miss_v 
                        | calc_status.mem3_exception_v 
-                       | calc_status.mem3_ret_v;
+                       | calc_status.mem3_ret_v;*/
 
 assign chk_poison_ex_o  = reset_i
                        | calc_status.mem3_cache_miss_v 
                        | calc_status.mem3_exception_v 
                        | calc_status.mem3_ret_v;
+
+assign chk_poison_isd_o = chk_poison_ex_o | mispredict_v;
 
 endmodule : bp_be_detector


### PR DESCRIPTION
Simplified the RTL in the detector and dcache module to reduce the number of lines in the code and to enhance the readability respectively. The post-synth PPA before and after the change is as follows (towers_rom):

Before:-
Performance: 404MHz
Power: 1.2599e+05uW
Area: 1283284.900015um^2

After:-
Performance: 411.5MHz
Power: 1.2605e+05uW
Area: 1282741.156035um^2