### PR TITLE
BTB Memory Clock Gating

### DIFF
--- a/bp_fe/src/v/bp_fe_btb.v
+++ b/bp_fe/src/v/bp_fe_btb.v
@@ -49,6 +49,7 @@ bsg_mem_1r1w
  #(.width_p(eaddr_width_p)
    ,.els_p(2**bp_fe_pc_gen_btb_idx_width_lp)
    ,.addr_width_lp(bp_fe_pc_gen_btb_idx_width_lp)
+   ,.enable_clock_gating_p(1'b1)
    ) 
  bsg_mem_1rw_sync_synth_1 
   (.w_clk_i(clk_i)

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -67,6 +67,8 @@ $BSG_IP_CORES_DIR/bsg_misc/bsg_round_robin_arb.v
 $BSG_IP_CORES_DIR/bsg_misc/bsg_scan.v
 $BSG_IP_CORES_DIR/bsg_noc/bsg_mesh_router.v
 $BSG_IP_CORES_DIR/bsg_noc/bsg_mesh_router_buffered.v
+$BSG_IP_CORES_DIR/bsg_misc/bsg_clkgate_optional.v
+$BSG_IP_CORES_DIR/bsg_misc/bsg_dlatch.v
 ## BE files
 $BP_BE_DIR/src/v/bp_be_top.v
 # Calculator


### PR DESCRIPTION
From a high level view, not every instruction requires us to update the branch related memory since not every instruction is a new branch, and the cycles where we don’t have to update branch related memory are cycles where we can save power. We think that we can reduce the power usage by implementing clock gating logic for the branch target buffer memory.

Here is our baseline

BASELINE INFO | Instr/S | J/Instr | Area (um^2)
-- | -- | -- | --
towers_rom | 1.7172e8 | 4.2744e-10 | 1333894.888021
vvadd_rom | 2.6003e8 | 2.7574-10 | 1333894.888021
multiply_rom | 1.6439e8 | 4.5441e-10 | 1333894.888021
median_rom | 2.2896e8 | 3.2102e-10 | 1333894.888021
average | 2.06275e8 | 3.696525e-10 | 1333894.888021

Here is our ppa after the implementation

BASELINEINFO | Instr/S | J/Instr | Area (um^2)
-- | -- | -- | --
towers_rom | 1.7627e8 | 3.9542e-10 | 1339819.217655
vvadd_rom | 2.6692e8 | 2.4801e-10 | 1339819.217655
multiply_rom | 1.6875e8 | 4.2012e-10 | 1339819.217655
median_rom | 2.3503e8 | 2.9230e-10 | 1339819.217655
average | 2.1174e8 | 3.3896e-10 | 1339819.217655

There is a 2.6494% increase in Instr/S
There is a 8.3031% decrease in J/Instr
The cost of this optimization is a 0.4441% increase in chip area, which is relatively negligible.
We think this optimization is pretty much free ppa gains and is worth pulling.