### PR TITLE
pparrot harden regfile

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_regfile.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_regfile.v
@@ -92,6 +92,7 @@ logic [reg_addr_width_lp-1:0] rs1_addr_r     , rs2_addr_r;
 logic [reg_addr_width_lp-1:0] rs1_reread_addr, rs2_reread_addr;
 
 // Datapath
+/*
 bsg_mem_2r1w_sync 
  #(.width_p(reg_data_width_lp)
    ,.els_p(rf_els_lp)
@@ -115,6 +116,50 @@ bsg_mem_2r1w_sync
    ,.r1_addr_i(rs2_reread_addr)
    ,.r1_data_o(rs2_reg_data)
    );
+
+*/
+
+bsg_mem_1r1w_sync 
+ #(.width_p(reg_data_width_lp)
+   ,.els_p(rf_els_lp)
+   ,.read_write_same_addr_p(1) // We can't actually read/write the same address, but this should 
+                               //   be taken care of by forwarding and otherwise the assertion is
+                               //   annoying
+   )
+ rf1
+  (.clk_i(clk_i)
+   ,.reset_i(reset_i)
+
+   ,.w_v_i(rd_w_v_i)
+   ,.w_addr_i(rd_addr_i)
+   ,.w_data_i(rd_data_i)
+
+   ,.r_v_i(rs1_read_v)
+   ,.r_addr_i(rs1_reread_addr)
+   ,.r_data_o(rs1_reg_data)
+   );
+
+
+bsg_mem_1r1w_sync 
+ #(.width_p(reg_data_width_lp)
+   ,.els_p(rf_els_lp)
+   ,.read_write_same_addr_p(1) // We can't actually read/write the same address, but this should 
+                               //   be taken care of by forwarding and otherwise the assertion is
+                               //   annoying
+   )
+ rf2
+  (.clk_i(clk_i)
+   ,.reset_i(reset_i)
+
+   ,.w_v_i(rd_w_v_i)
+   ,.w_addr_i(rd_addr_i)
+   ,.w_data_i(rd_data_i)
+
+   ,.r_v_i(rs2_read_v)
+   ,.r_addr_i(rs2_reread_addr)
+   ,.r_data_o(rs2_reg_data)
+   );
+
 
 // Save the last issued register addresses
 bsg_dff_en 


### PR DESCRIPTION

testbench | Power baseline post synth | Power SRAM post synth | Difference
-- | -- | -- | --
none | 1.2011e5 uW | 1.1333e5 uW | -5.64%
median | 1.1842e5 uW | 1.1202e5 uW | -5.40%
multiply | 1.1769e5 uW | 1.1172e5 uW | -5.07%
tower | 1.2628e5 uW | 1.1786e5 uW | -6.67%
vvadd | 1.1553e5 uW | 1.0902e5 uW | -5.63%

Total cell Area:
Baseline post synth:		1283284
Harden SRAM post synth:	1229303
Difference:			-4.2%

Performance:
Baseline post synth:		2.5 ns
Harden SRAM post synth:	2.5 - 0.06 ns = 2.44 ns
Difference:			-2.4%

Other file changes:
add mem cfg file in 
ee477-designs/toplevels/bsg_black_parrot_be/cfg/saed_90/saed90_64x32_1r1w_bit.cfg

add 64x32 macro option in this file
bsg_ip_cores/hard/saed_90/bsg_mem/bsg_mem_1r1w_sync.v

credit to Mingcun Fan