### PR TITLE
Reduction of network width by dividing the packets into smaller blocks using serializer and deserializer modules

### DIFF
--- a/bp_me/src/v/network/bp_coherence_network.v
+++ b/bp_me/src/v/network/bp_coherence_network.v
@@ -29,6 +29,8 @@ module bp_coherence_network
 
     // Default parameters
     , parameter debug_p                  = 0
+    , localparam num_ser_blocks_lp       = 2
+    , localparam fifo_els_lp             = 0
 
     // Derived parameters
     , localparam lg_num_lce_lp          = `BSG_SAFE_CLOG2(num_lce_p)
@@ -143,6 +145,8 @@ module bp_coherence_network
       ,.num_dst_p(num_lce_p)
       ,.debug_p(debug_p)
       ,.repeater_output_p(repeater_output_lp)
+      ,.reduced_payload_width_p((bp_cce_lce_cmd_width_lp+num_ser_blocks_lp-1)/num_ser_blocks_lp)
+      ,.fifo_els_p(fifo_els_lp)
       )
     cce_lce_cmd_network
      (.clk_i(clk_i)
@@ -164,6 +168,8 @@ module bp_coherence_network
       ,.num_dst_p(num_lce_p)
       ,.debug_p(debug_p)
       ,.repeater_output_p(repeater_output_lp)
+      ,.reduced_payload_width_p((bp_cce_lce_data_cmd_width_lp+num_ser_blocks_lp-1)/num_ser_blocks_lp)
+      ,.fifo_els_p(fifo_els_lp)
       )
     cce_lce_data_cmd_network
      (.clk_i(clk_i)
@@ -178,6 +184,7 @@ module bp_coherence_network
       ,.dst_ready_i(lce_data_cmd_ready_i)
       );
 
+
   // LCE Request Network - (LCE->trans_net->CCE)
   bp_coherence_network_channel
     #(.packet_width_p(bp_lce_cce_req_width_lp)
@@ -185,6 +192,8 @@ module bp_coherence_network
       ,.num_dst_p(num_cce_p)
       ,.debug_p(debug_p)
       ,.repeater_output_p(repeater_output_lp)
+      ,.reduced_payload_width_p((bp_lce_cce_req_width_lp+num_ser_blocks_lp-1)/num_ser_blocks_lp)
+      ,.fifo_els_p(fifo_els_lp)
       )
     lce_cce_req_network
      (.clk_i(clk_i)
@@ -198,7 +207,6 @@ module bp_coherence_network
       ,.dst_v_o(lce_req_v_o)
       ,.dst_ready_i(lce_req_ready_i)
       );
-
   // LCE Response Network - (LCE->trans_net->CCE)
   bp_coherence_network_channel
     #(.packet_width_p(bp_lce_cce_resp_width_lp)
@@ -206,6 +214,8 @@ module bp_coherence_network
       ,.num_dst_p(num_cce_p)
       ,.debug_p(debug_p)
       ,.repeater_output_p(repeater_output_lp)
+      ,.reduced_payload_width_p((bp_lce_cce_resp_width_lp+num_ser_blocks_lp-1)/num_ser_blocks_lp)
+      ,.fifo_els_p(fifo_els_lp)
       )
     lce_cce_resp_network
      (.clk_i(clk_i)
@@ -227,6 +237,8 @@ module bp_coherence_network
       ,.num_dst_p(num_cce_p)
       ,.debug_p(debug_p)
       ,.repeater_output_p(repeater_output_lp)
+      ,.reduced_payload_width_p((bp_lce_cce_data_resp_width_lp+num_ser_blocks_lp-1)/num_ser_blocks_lp)
+      ,.fifo_els_p(fifo_els_lp)
       )
     lce_cce_data_resp_network
      (.clk_i(clk_i)
@@ -248,6 +260,8 @@ module bp_coherence_network
       ,.num_dst_p(num_lce_p)
       ,.debug_p(debug_p)
       ,.repeater_output_p(repeater_output_lp)
+      ,.reduced_payload_width_p((bp_lce_lce_tr_resp_width_lp+num_ser_blocks_lp-1)/num_ser_blocks_lp)
+      ,.fifo_els_p(fifo_els_lp)
       )
     lce_lce_tr_resp_network
      (.clk_i(clk_i)

--- a/bp_me/src/v/network/bp_coherence_network_individual_input_serializer.v
+++ b/bp_me/src/v/network/bp_coherence_network_individual_input_serializer.v
@@ -1,0 +1,94 @@
+/**
+ *
+ * Name: bp_coherence_network_individual_input_serializer.v
+ *
+ * Description:
+ *    This block "divides" the input packet in N smaller packets and sends
+ *    them sequentially through the network. This allows us to use a smaller
+ *    network (less area) but imposes a higher latency (less performance)
+*/
+
+module bp_coherence_network_individual_input_serializer
+  #(parameter packet_width_p                     = "inv"
+    , parameter num_src_p                        = "inv"
+    , parameter num_dst_p                        = "inv"
+    , parameter reduced_payload_width_p          = "inv" // Each "divided" package will need to be attached to dst_id
+
+    // Derived parameters
+    , localparam mesh_width_lp                  = `BSG_MAX(num_src_p,num_dst_p)
+    , localparam lg_mesh_width_lp               = `BSG_SAFE_CLOG2(mesh_width_lp)
+    , localparam dst_id_width_lp                = `BSG_SAFE_CLOG2(num_dst_p)
+    , localparam num_serialized_blocks_lp       = (packet_width_p+reduced_payload_width_p-1)/reduced_payload_width_p
+    , localparam reduced_packet_width_lp        = (num_serialized_blocks_lp == 1) ? packet_width_p : reduced_payload_width_p + lg_mesh_width_lp
+    , localparam log_num_serialized_blocks_lp   = `BSG_SAFE_CLOG2(num_serialized_blocks_lp)
+    )
+  (input                                        clk_i
+   , input                                      reset_i
+
+   // Input interface
+   , input [packet_width_p-1:0]                 src_data_i
+   , input                                      src_v_i
+   , output                                     src_ready_o
+
+   // Output interface
+   , output [reduced_packet_width_lp-1:0]       src_serialized_data_o 
+   , output                                     src_serialized_v_o
+   , input                                      src_serialized_ready_i
+);
+
+  // If there is no serialization, don't do anything
+  if(num_serialized_blocks_lp == 1) begin
+    assign src_serialized_data_o = src_data_i;
+    assign src_serialized_v_o = src_v_i;
+    assign src_ready_o = src_serialized_ready_i;
+  end
+
+  // If there is serialization:
+  else begin
+    logic [packet_width_p-1:0]                    src_data_i_mux, src_data_i_mux_r;
+    logic [log_num_serialized_blocks_lp-1:0]      counter, counter_n, counter_n_aux;
+    logic [reduced_payload_width_p-1:0]           src_serialized_payload_data;
+    logic [lg_mesh_width_lp-1:0]                  dst_id;
+
+    // Getting the destination from the original packet
+    assign dst_id = (lg_mesh_width_lp)'(src_data_i_mux[packet_width_p-1 -: dst_id_width_lp]);
+    // assign dst_id = src_data_i_mux[packet_width_p-1 -: dst_id_width_lp];
+
+    always_comb begin
+      // MUX that choses the appropiate section of src_data_i_mux as the output,
+      // depending on the value of counter.
+      int i;
+      for (i=0; i<num_serialized_blocks_lp-1; i=i+1) begin: rof
+        if( counter == log_num_serialized_blocks_lp'(i))  src_serialized_payload_data = src_data_i_mux[i*reduced_payload_width_p +: reduced_payload_width_p];
+      end //rof
+      // The following default includes the next (commented) case
+      // log_num_serialized_blocks_lp'(num_serialized_blocks_lp-1)  :   \
+      // CHECK FOR BUG
+      if( counter >= log_num_serialized_blocks_lp'(num_serialized_blocks_lp-1) ) src_serialized_payload_data = (reduced_payload_width_p)'(src_data_i_mux[packet_width_p-1 -: packet_width_p - ( (num_serialized_blocks_lp - 1) * reduced_payload_width_p)]);
+    end
+
+    // Next value for the two registers:
+    assign counter_n_aux = ( ( counter == (log_num_serialized_blocks_lp)'(0) ) & ( !src_v_i ) ) ? (log_num_serialized_blocks_lp)'(0) : ( counter == (log_num_serialized_blocks_lp)'(num_serialized_blocks_lp-1) ) ? (log_num_serialized_blocks_lp)'(0) :  counter + (log_num_serialized_blocks_lp)'(1);
+    assign counter_n = (src_serialized_ready_i) ? counter_n_aux : counter;
+    assign src_data_i_mux = ( counter == (log_num_serialized_blocks_lp)'(0) ) ? src_data_i : src_data_i_mux_r;
+
+    // Logic for the ready_o signal in the input interface
+    assign src_ready_o = ( counter == (log_num_serialized_blocks_lp)'(0) ) & src_serialized_ready_i;
+
+    // Logic for the v_o signal in the output interface, and the actual output
+    assign src_serialized_v_o = src_v_i | ( counter != (log_num_serialized_blocks_lp)'(0) );
+    assign src_serialized_data_o = { dst_id, src_serialized_payload_data };
+
+    // Registers
+    always_ff @ (posedge clk_i) begin
+      if (reset_i) begin
+        counter <= '0;
+        src_data_i_mux_r <= '0;
+      end
+      else begin
+        counter <= counter_n;
+        src_data_i_mux_r <= src_data_i_mux;
+      end
+    end
+  end
+endmodule

--- a/bp_me/src/v/network/bp_coherence_network_individual_output_deserializer.v
+++ b/bp_me/src/v/network/bp_coherence_network_individual_output_deserializer.v
@@ -1,0 +1,82 @@
+/**
+ *
+ * Name: bp_coherence_network_individual_output_deserializer.v
+ *
+ * Description:
+ *    --
+*/
+
+module bp_coherence_network_individual_output_deserializer
+  #(parameter packet_width_p                     = "inv"
+    , parameter num_src_p                        = "inv"
+    , parameter num_dst_p                        = "inv"
+    , parameter reduced_payload_width_p          = "inv" // Each "divided" package will need to be attached to dst_id
+
+    // Derived parameters
+    , localparam mesh_width_lp                  = `BSG_MAX(num_src_p,num_dst_p)
+    , localparam lg_mesh_width_lp               = `BSG_SAFE_CLOG2(mesh_width_lp)
+    , localparam dst_id_width_lp                = `BSG_SAFE_CLOG2(num_dst_p)
+    , localparam num_serialized_blocks_lp       = (packet_width_p+reduced_payload_width_p-1)/reduced_payload_width_p
+    , localparam reduced_packet_width_lp        = (num_serialized_blocks_lp == 1) ? packet_width_p : reduced_payload_width_p + lg_mesh_width_lp
+    , localparam log_num_serialized_blocks_lp   = `BSG_SAFE_CLOG2(num_serialized_blocks_lp)
+    )
+  (input                                        clk_i
+   , input                                      reset_i
+
+   // Output interface
+   , output [packet_width_p-1:0]                dst_data_o
+   , output                                     dst_v_o
+   , input                                      dst_ready_i
+
+   // Input interface
+   , input [reduced_packet_width_lp-1:0]        dst_serialized_data_i
+   , input                                      dst_serialized_v_i
+   , output                                     dst_serialized_ready_o
+);
+
+  // If there is no serialization, don't do anything
+  if(num_serialized_blocks_lp == 1) begin
+    assign dst_data_o = dst_serialized_data_i;
+    assign dst_v_o = dst_serialized_v_i;
+    assign dst_serialized_ready_o = dst_ready_i;
+  end
+
+  // If there is serialization:
+  else begin
+    logic [num_serialized_blocks_lp-2:0][reduced_payload_width_p-1:0]       dst_serialized_payload_data_r, dst_serialized_payload_data_r_n;
+  logic [log_num_serialized_blocks_lp-1:0]      counter, counter_n;
+
+    // Next value for the first register
+    assign dst_serialized_payload_data_r_n[0] = (dst_serialized_v_i & dst_serialized_ready_o ) ? dst_serialized_data_i[reduced_payload_width_p-1:0] : dst_serialized_payload_data_r[0];
+    // Next value for the other registers and the first parts of dst_data_o
+    genvar i;
+    for (i=0; i<num_serialized_blocks_lp-2; i=i+1) begin: rof
+      assign dst_serialized_payload_data_r_n[i+1] = ( dst_serialized_v_i & dst_serialized_ready_o ) ? dst_serialized_payload_data_r[i] : dst_serialized_payload_data_r[i+1];
+      assign dst_data_o[i*reduced_payload_width_p +: reduced_payload_width_p] = dst_serialized_payload_data_r[num_serialized_blocks_lp-2-i];
+    end //rof
+    if(num_serialized_blocks_lp >= 2) assign dst_data_o[(num_serialized_blocks_lp-2)*reduced_payload_width_p +: reduced_payload_width_p] = dst_serialized_payload_data_r[0];
+    assign dst_data_o[packet_width_p-1 : (num_serialized_blocks_lp-1)*reduced_payload_width_p] = dst_serialized_data_i[packet_width_p - ( (num_serialized_blocks_lp - 1) * reduced_payload_width_p )-1:0];
+  
+    // Next value for the counter
+    assign counter_n = ( !(dst_serialized_v_i & dst_serialized_ready_o) ) ? counter : ( counter == (log_num_serialized_blocks_lp)'(num_serialized_blocks_lp-1) ) ? (log_num_serialized_blocks_lp)'(0) :  counter + (log_num_serialized_blocks_lp)'(1);
+
+    // This module is always ready to receive data, unless the output is ready
+    // and cannot be received (which shouldn't happen in our system)
+    assign dst_serialized_ready_o = (!dst_v_o) | (dst_ready_i);
+
+    // Logic for the v_o in the output
+    assign dst_v_o = ( counter == (log_num_serialized_blocks_lp)'(num_serialized_blocks_lp-1) );
+
+    // Registers
+    always_ff @ (posedge clk_i) begin
+      if (reset_i) begin
+        dst_serialized_payload_data_r <= '0;
+        counter <= '0;
+      end
+      else begin
+        dst_serialized_payload_data_r <= dst_serialized_payload_data_r_n;
+        counter <= counter_n;
+      end
+    end
+  end
+endmodule

--- a/bp_me/src/v/network/bp_coherence_network_input_serializer.v
+++ b/bp_me/src/v/network/bp_coherence_network_input_serializer.v
@@ -1,0 +1,85 @@
+/**
+ *
+ * Name: bp_coherence_network_input_serializer.v
+ *
+ * Description:
+ *    This block "divides" the input packet in N smaller packets and sends
+ *    them sequentially through the network. This allows us to use a smaller
+ *    network (less area) but imposes a higher latency (less performance)
+*/
+
+module bp_coherence_network_input_serializer
+  #(parameter packet_width_p                     = "inv"
+    , parameter num_src_p                        = "inv"
+    , parameter num_dst_p                        = "inv"
+    , parameter reduced_payload_width_p          = "inv"
+    , parameter fifo_els_p                       = "inv"
+
+    // Derived parameters
+    , localparam mesh_width_lp              = `BSG_MAX(num_src_p,num_dst_p)
+    , localparam lg_mesh_width_lp           = `BSG_SAFE_CLOG2(mesh_width_lp)
+    , localparam num_serialized_blocks_lp   = (packet_width_p+reduced_payload_width_p-1)/reduced_payload_width_p
+    , localparam reduced_packet_width_lp    = (num_serialized_blocks_lp == 1) ? packet_width_p : reduced_payload_width_p + lg_mesh_width_lp
+    )
+  (input                                              clk_i
+   , input                                            reset_i
+
+   // Input interface
+   , input [num_src_p-1:0][packet_width_p-1:0]        src_data_i
+   , input [num_src_p-1:0]                            src_v_i
+   , output[num_src_p-1:0]                            src_ready_o
+
+   // Output Interface
+   , output [num_src_p-1:0][reduced_packet_width_lp-1:0]       src_serialized_data_o
+   , output [num_src_p-1:0]                                    src_serialized_v_o
+   , input  [num_src_p-1:0]                                    src_serialized_ready_i
+);
+
+  logic [num_src_p-1:0][packet_width_p-1:0] src_data_i_int;
+  logic [num_src_p-1:0] yumi_fifo, valid_fifo;
+  // Instantiate one serializer for each input port of the network
+  genvar i;
+  for (i = 0; i < num_src_p; i=i+1) begin: rof
+    if(fifo_els_p == 0) begin
+      assign src_data_i_int[i] = src_data_i[i];
+      assign valid_fifo[i] = src_v_i[i];
+      assign src_ready_o[i] = yumi_fifo[i];
+    end
+    else begin
+      bsg_fifo_1r1w_large 
+         #(  .width_p(packet_width_p)
+           , .els_p(fifo_els_p)
+          )
+      ser_fifo
+       ( .clk_i(clk_i)
+       , .reset_i(reset_i)
+ 
+       , .data_i(src_data_i[i])
+       , .v_i(src_v_i[i] & src_ready_o[i])
+       , .ready_o(src_ready_o[i])
+
+       , .v_o(valid_fifo[i])
+       , .data_o(src_data_i_int[i])
+       , .yumi_i(yumi_fifo[i] & valid_fifo[i])
+       ); 
+    end
+
+    bp_coherence_network_individual_input_serializer
+      #(.packet_width_p(packet_width_p)
+        ,.num_src_p(num_src_p)
+        ,.num_dst_p(num_dst_p)
+        ,.reduced_payload_width_p(reduced_payload_width_p)
+        )
+      bp_coherence_network_individual_input_serializer
+        (.clk_i(clk_i)
+        ,.reset_i(reset_i)
+        ,.src_data_i(src_data_i_int[i])
+        ,.src_v_i(valid_fifo[i])
+        ,.src_ready_o(yumi_fifo[i])
+        ,.src_serialized_data_o(src_serialized_data_o[i])
+        ,.src_serialized_v_o(src_serialized_v_o[i])
+        ,.src_serialized_ready_i(src_serialized_ready_i[i])
+      );
+  end //rof
+
+endmodule

--- a/bp_me/src/v/network/bp_coherence_network_output_deserializer.v
+++ b/bp_me/src/v/network/bp_coherence_network_output_deserializer.v
@@ -1,0 +1,58 @@
+/**
+ *
+ * Name: bp_coherence_network_output_deserializer.v
+ *
+ * Description:
+ *    --
+*/
+
+module bp_coherence_network_output_deserializer
+  #(parameter packet_width_p                     = "inv"
+    , parameter num_src_p                        = "inv"
+    , parameter num_dst_p                        = "inv"
+    , parameter reduced_payload_width_p          = "inv"
+
+    // Derived parameters
+    , localparam mesh_width_lp              = `BSG_MAX(num_src_p,num_dst_p)
+    , localparam lg_mesh_width_lp           = `BSG_SAFE_CLOG2(mesh_width_lp)
+    , localparam num_serialized_blocks_lp   = (packet_width_p+reduced_payload_width_p-1)/reduced_payload_width_p
+    , localparam reduced_packet_width_lp    = (num_serialized_blocks_lp == 1) ? packet_width_p : reduced_payload_width_p + lg_mesh_width_lp
+    )
+  (input                                                      clk_i
+   , input                                                    reset_i
+
+   // Output interface
+   , output [num_dst_p-1:0][packet_width_p-1:0]               dst_data_o
+   , output [num_dst_p-1:0]                                   dst_v_o
+   , input  [num_dst_p-1:0]                                   dst_ready_i
+
+   // Input interface
+   , input  [num_dst_p-1:0][reduced_packet_width_lp-1:0]      dst_serialized_data_i
+   , input  [num_dst_p-1:0]                                   dst_serialized_v_i
+   , output [num_dst_p-1:0]                                   dst_serialized_ready_o
+);
+
+  // Instantiate one serializer for each input port of the network
+  genvar i;
+  for (i = 0; i < num_dst_p; i=i+1) begin: rof
+    // Instantiations
+    
+    bp_coherence_network_individual_output_deserializer
+      #(.packet_width_p(packet_width_p)
+        ,.num_src_p(num_src_p)
+        ,.num_dst_p(num_dst_p)
+        ,.reduced_payload_width_p(reduced_payload_width_p)
+        )
+      bp_coherence_network_individual_output_deserializer
+        (.clk_i(clk_i)
+        ,.reset_i(reset_i)
+        ,.dst_data_o(dst_data_o[i])
+        ,.dst_v_o(dst_v_o[i])
+        ,.dst_ready_i(dst_ready_i[i])
+        ,.dst_serialized_data_i(dst_serialized_data_i[i])
+        ,.dst_serialized_v_i(dst_serialized_v_i[i])
+        ,.dst_serialized_ready_o(dst_serialized_ready_o[i])
+      );
+  end //rof
+
+endmodule


### PR DESCRIPTION
Serializer and deserializer modules were created. This reduces the width of the network but increases its latency.

Either the number of blocks into which the packets are divided or the width of the smaller blocks is configurable.

A FIFO can optionally be added before each serializer module, to prevent messages being dropped because of the added latency.