### PR TITLE
Upgrade demos with atomics

### DIFF
--- a/bp_common/test/Makefile.frag
+++ b/bp_common/test/Makefile.frag
@@ -1,13 +1,16 @@
 BP_DEMOS = \
-  hello_world        \
-  atomic_queue_demo  \
-  basic_demo         \
-  queue_demo_2       \
-  queue_demo_4       \
-  queue_demo_8       \
-  copy_example       \
-  trap_demo          \
-  atomic_demo        \
+  hello_world        	\
+  atomic_queue_demo  	\
+  basic_demo         	\
+  atomic_queue_demo_2	\
+  atomic_queue_demo_4	\
+  atomic_queue_demo_8	\
+  queue_demo_2       	\
+  queue_demo_4       	\
+  queue_demo_8       	\
+  copy_example       	\
+  trap_demo          	\
+  atomic_demo        	\
   hello_world_atomic
 
 RV64_BENCHMARKS = \

--- a/bp_common/test/Makefile.frag
+++ b/bp_common/test/Makefile.frag
@@ -5,9 +5,6 @@ BP_DEMOS = \
   queue_demo_2       \
   queue_demo_4       \
   queue_demo_8       \
-  reloc_queue_demo_2 \
-  reloc_queue_demo_4 \
-  reloc_queue_demo_8 \
   copy_example       \
   trap_demo          \
   atomic_demo        \

--- a/bp_common/test/Makefile.frag
+++ b/bp_common/test/Makefile.frag
@@ -1,5 +1,6 @@
 BP_DEMOS = \
   hello_world        \
+  atomic_queue_demo  \
   basic_demo         \
   queue_demo_2       \
   queue_demo_4       \
@@ -9,7 +10,8 @@ BP_DEMOS = \
   reloc_queue_demo_8 \
   copy_example       \
   trap_demo          \
-  atomic_demo
+  atomic_demo        \
+  hello_world_atomic
 
 RV64_BENCHMARKS = \
   median   \

--- a/bp_common/test/src/demos/Makefile
+++ b/bp_common/test/src/demos/Makefile
@@ -20,6 +20,9 @@ bp-demo-s    : $(foreach x,$(subst -,_,$(BP_DEMOS_C)),$(x).s)
 queue_demo_%.s:
 	$(RISCV_GCC) -DNUM_CORES=$(notdir $*) -S -o src/queue_demo_$(notdir $*).s src/queue_demo.c
 
+atomic_queue_demo_%.s:
+	$(RISCV_GCC) -DNUM_CORES=$(notdir $*) -S -o src/atomic_queue_demo_$(notdir $*).s src/atomic_queue_demo.c
+
 %.s:
 	$(RISCV_GCC) -S -o src/$@ src/$*.c 
 

--- a/bp_common/test/src/demos/Makefile
+++ b/bp_common/test/src/demos/Makefile
@@ -14,7 +14,7 @@ bp-demo-riscv: $(foreach x,$(subst -,_,$(BP_DEMOS)),$(x).riscv)
 bp-demo-s    : $(foreach x,$(subst -,_,$(BP_DEMOS_C)),$(x).s)
 
 %.riscv:
-	$(RISCV_GCC) -o $@ src/$*.s src/start.S src/exception.S src/atomics.S src/emulation.c
+	$(RISCV_GCC) -o $@ src/$*.s src/start.S src/exception.S src/atomics.S src/emulation.c src/bp_utils.h src/bp_utils.c
 	$(RISCV_OBJDUMP) $@ > $*.dump
 
 queue_demo_%.s:

--- a/bp_common/test/src/demos/Makefile
+++ b/bp_common/test/src/demos/Makefile
@@ -20,9 +20,6 @@ bp-demo-s    : $(foreach x,$(subst -,_,$(BP_DEMOS_C)),$(x).s)
 queue_demo_%.s:
 	$(RISCV_GCC) -DNUM_CORES=$(notdir $*) -S -o src/queue_demo_$(notdir $*).s src/queue_demo.c
 
-reloc_queue_demo_%.s:
-	$(RISCV_GCC) -DNUM_CORES=$(notdir $*) -S -o src/reloc_queue_demo_$(notdir $*).s src/reloc_queue_demo.c
-
 %.s:
 	$(RISCV_GCC) -S -o src/$@ src/$*.c 
 

--- a/bp_common/test/src/demos/Makefile.frag
+++ b/bp_common/test/src/demos/Makefile.frag
@@ -4,9 +4,6 @@ BP_DEMOS_C = \
 	queue_demo_2       \
 	queue_demo_4       \
 	queue_demo_8       \
-	reloc_queue_demo_2 \
-	reloc_queue_demo_4 \
-	reloc_queue_demo_8 \
 	copy_example       \
 	trap_demo          \
 	atomic_demo		   \

--- a/bp_common/test/src/demos/Makefile.frag
+++ b/bp_common/test/src/demos/Makefile.frag
@@ -1,12 +1,14 @@
 BP_DEMOS_C = \
-	basic_demo         \
-	atomic_queue_demo  \
-	queue_demo_2       \
-	queue_demo_4       \
-	queue_demo_8       \
-	copy_example       \
-	trap_demo          \
-	atomic_demo		   \
+	basic_demo         		\
+	atomic_queue_demo_2		\
+	atomic_queue_demo_4		\
+	atomic_queue_demo_8		\
+	queue_demo_2       		\
+	queue_demo_4       		\
+	queue_demo_8       		\
+	copy_example       		\
+	trap_demo          		\
+	atomic_demo		   		\
 	hello_world_atomic
 
 BP_DEMOS_S = \

--- a/bp_common/test/src/demos/Makefile.frag
+++ b/bp_common/test/src/demos/Makefile.frag
@@ -1,5 +1,6 @@
 BP_DEMOS_C = \
 	basic_demo         \
+	atomic_queue_demo  \
 	queue_demo_2       \
 	queue_demo_4       \
 	queue_demo_8       \
@@ -8,7 +9,8 @@ BP_DEMOS_C = \
 	reloc_queue_demo_8 \
 	copy_example       \
 	trap_demo          \
-	atomic_demo
+	atomic_demo		   \
+	hello_world_atomic
 
 BP_DEMOS_S = \
 	hello_world

--- a/bp_common/test/src/demos/src/atomic_queue_demo.c
+++ b/bp_common/test/src/demos/src/atomic_queue_demo.c
@@ -1,0 +1,179 @@
+#include <stdint.h>
+#include "bp_utils.h"
+
+#define QUEUE_LENGTH 32
+
+#ifndef NUM_CORES
+#define NUM_CORES 8
+#endif
+
+#define NUM_READERS (NUM_CORES/2)
+#define NUM_WRITERS (NUM_CORES/2)
+#define NUM_OPS 10
+
+// this is just a circular queue
+// we dequeue at the head index and enqueue from the tail index
+typedef struct {
+    uint64_t head_index;
+    uint64_t tail_index;
+    uint64_t lock_address;
+    uint64_t queue_buffer[QUEUE_LENGTH];
+} shared_queue;
+
+
+
+// FIXME: we can change this into a struct if we
+// want a more complex queue
+typedef uint64_t queue_item;
+
+// declare everything volatile, so loops don't optimize themselves away
+volatile shared_queue queue;
+
+volatile uint64_t start_barrier_mem = 0;
+volatile uint64_t end_barrier_mem = 0;
+
+void lock_queue(uint64_t core_id) {
+    uint64_t swap_value = 1;
+
+    do {
+        __asm__ volatile("amoswap.d %0, %2, (%1)": "=r"(swap_value) 
+                                                 : "r"(&(queue.lock_address)), "r"(swap_value)
+                                                 :);
+    } while (swap_value != 0);
+}
+
+void unlock_queue(uint64_t core_id) {
+    uint64_t swap_value = 0;
+    __asm__ volatile("amoswap.d %0, %2, (%1)": "=r"(swap_value) 
+                                                 : "r"(&(queue.lock_address)), "r"(swap_value)
+                                                 :);
+}
+
+// attempts to enqueue an item.
+// returns 0 if successful
+// returns 1 if unsuccessful (the queue was full)
+uint64_t enqueue(uint64_t core_id, queue_item enqueue_item) {
+    uint64_t status = 0;
+    // we actually don't care if the head index changes between
+    // us checking and us enqueuing because we don't need to
+    // change things based on head index
+    // We might miss a consumer dequeue, so we don't enqueue
+    // immediately to fill an empty slot, but so what
+    lock_queue(core_id);
+
+    // if the queue is full, return an error
+    // the queue is full
+    if ((queue.tail_index + 1) % QUEUE_LENGTH == queue.head_index) {
+        status = 1;
+        goto done_enqueue;
+    }
+
+    // FIXME: if a queue_item becomes a struct, change to copying
+    // in the struct fields
+    queue.queue_buffer[queue.tail_index] = enqueue_item;
+
+    // update the tail index at the very end, so if a consumer
+    // checks to dequeue, the item will be ready
+    queue.tail_index = (queue.tail_index + 1) % QUEUE_LENGTH;
+    //printf("Core %d enqueued %d\n", core_id, enqueue_item);
+
+done_enqueue:
+    unlock_queue(core_id);
+    return status;
+}
+
+// attempts to dequeue an item.
+// returns 0 if successful
+// returns 1 if unsuccessful (the queue was full)
+// the item is returned in dequeue_item
+uint64_t dequeue(uint64_t core_id, queue_item *dequeue_item) {
+    uint64_t status = 0;
+    uint64_t print_addr = (uint64_t)(0x000000008FFFFFFF);
+    uint64_t print_item;
+
+    // we actually don't care if the tail index changes between
+    // us checking and us dequeuing because we don't need to
+    // change things based on tail index
+    // We might miss a producer enqueue, so we don't dequeue
+    // a new item immediately, but so what
+    lock_queue(core_id);
+
+    // check if the queue is empty
+    if (queue.tail_index == queue.head_index) {
+        status = 1;
+        goto done_dequeue;
+    }
+
+    // FIXME: if a queue_item becomes a struct, change to copying in the struct fields
+    *dequeue_item = queue.queue_buffer[queue.head_index];
+
+    // update the head index at the very end, so if a producer checks to
+    // enqueue, the item will have already been copied out
+    queue.head_index = (queue.head_index + 1) % QUEUE_LENGTH;
+    print_item = *dequeue_item;
+    //printf("Core %d dequeued %d\n", core_id, *dequeue_item);
+    __asm__ volatile("sb %0, 0(%1)": : "r"(print_item), "r"(print_addr):);
+
+done_dequeue:
+    unlock_queue(core_id);
+    return status;
+}
+
+// TODO: what actually happens when we enqueue and dequeue
+// this will eventually become the function given to pthread_create
+uint64_t thread_main() {
+    // do some stuff, probably dependent on core ID (enqueue vs dequeue)
+    // find some inline assembly to read the hartID csr
+    uint64_t data = 0;
+    uint64_t core_id;
+    uint64_t status;
+    uint64_t num_operations = 0;
+    
+    __asm__ volatile("csrr %0, mhartid": "=r"(core_id): :);
+    // have the even cores enqueue and the odd ones dequeue
+    if (core_id % 2 == 0){
+        while(num_operations < NUM_OPS) {
+            status = enqueue(core_id, data);
+            if (status == 0) {
+                data++;
+                num_operations++;
+                //TODO: do something on enqueue
+            }
+        }
+    }
+    else {
+        while(num_operations < NUM_OPS) {
+            status = dequeue(core_id, &data);
+            if (status == 0) {
+                // TODO: do something with dequeued data...maybe print?
+                num_operations++;
+            }
+        }
+    }
+}
+
+uint64_t main(uint64_t argc, char * argv[]) {
+    uint64_t i;
+    uint64_t core_id;
+    __asm__ volatile("csrr %0, mhartid": "=r"(core_id): :);
+   
+    // only core 0 intializes data structures
+    if (core_id == 0) {
+        // initialize queue lock
+        queue.lock_address = 0;
+        // initialize queue structure
+        queue.head_index = 0;
+        queue.tail_index = 0;
+        for (i = 0; i < QUEUE_LENGTH; i++) {
+            queue.queue_buffer[i] = 0xdeadbeef;
+        }
+        start_barrier_mem = 0xdeadbeef;
+    }
+    else {
+        while (start_barrier_mem != 0xdeadbeef) { }
+    }
+    thread_main();
+
+    barrier_end(&end_barrier_mem, NUM_CORES);
+    return 0;
+}

--- a/bp_common/test/src/demos/src/bp_utils.c
+++ b/bp_common/test/src/demos/src/bp_utils.c
@@ -1,0 +1,34 @@
+#include <stdint.h>
+#include "bp_utils.h"
+
+void barrier_end(volatile uint64_t * barrier_address, uint64_t total_num_cores) {
+    uint64_t core_id;
+    uint64_t atomic_inc = 1;
+    uint64_t atomic_result;
+    __asm__ volatile("csrr %0, mhartid": "=r"(core_id): :);
+    
+    /* if we're not core 0, increment the barrier and then just loop */
+    if (core_id != 0) {
+        __asm__ volatile("amoadd.d %0, %2, (%1)": "=r"(atomic_result) 
+                                                : "r"(barrier_address), "r"(atomic_inc)
+                                                :);
+        while (1) { }
+    }
+    /* 
+     * if we're core 0, increment the barrier as well and then test if the
+     * barrier is equal to the total number of cores
+     */
+    else {
+        uint64_t finish_value = 0;
+        __asm__ volatile("amoadd.d %0, %2, (%1)": "=r"(atomic_result) 
+                                                : "r"(barrier_address), "r"(atomic_inc)
+                                                :);
+        while(*barrier_address < total_num_cores) {
+
+            
+        }
+        __asm__ volatile("csrw 0x800, 0;": 
+                                        : "r"(finish_value)
+                                        :);
+    }
+}

--- a/bp_common/test/src/demos/src/bp_utils.h
+++ b/bp_common/test/src/demos/src/bp_utils.h
@@ -1,0 +1,7 @@
+#ifndef BP_UTILS_H
+#define BP_UTILS_H
+#include <stdint.h>
+
+void barrier_end(volatile uint64_t *barrier_address, uint64_t total_num_cores);
+
+#endif

--- a/bp_common/test/src/demos/src/exception.S
+++ b/bp_common/test/src/demos/src/exception.S
@@ -8,9 +8,9 @@
 .type  decode_illegal, @function
 
 bp_mtvec_handler:
-    # Save the current stack pointer
+    # Swap in the machine mode stack pointer
     # Note: We only need to save the stack if we have a special emu stack. Security?
-    csrw mscratch, sp
+    csrrw sp, mscratch, sp 
 
     # Push temp registers onto stack
     sd x31, 0(sp)
@@ -42,7 +42,11 @@ bp_mtvec_handler:
     sd x5, -208(sp)
     sd x4, -216(sp)
     sd x3, -224(sp)
-    sd x2, -232(sp)
+    /* the user stack pointer needs to be saved slightly differently since it's in mscratch 
+     * at this point. On the upside, we can clobber almost anything we want now
+     */
+    csrr t0, mscratch
+    sd t0, -232(sp)
     sd x1, -240(sp)
     sd x0, -248(sp)
 
@@ -65,9 +69,14 @@ bp_mtvec_handler:
 
     # Pop temp registers from stack
     addi sp, sp, 256
+    # Save the machine mode scratch pointer in mscratch
+    csrw mscratch, sp
+
     ld x0, -248(sp)
     ld x1, -240(sp)
-    //ld x2, -232(sp)
+    /* we need to restore the user stack pointer at the end, so we can finish restoring
+     * user registers
+     */
     ld x3, -224(sp)
     ld x4, -216(sp)
     ld x5, -208(sp)
@@ -98,8 +107,8 @@ bp_mtvec_handler:
     ld x30, -8(sp)
     ld x31,  0(sp)
 
-    # Restore the stack pointer to restore registers
-    csrr sp, mscratch
+    # Restore the user stack pointer as the last thing we do
+    ld x2, -232(sp)
 
     # Return from the trap
     mret

--- a/bp_common/test/src/demos/src/hello_world_atomic.c
+++ b/bp_common/test/src/demos/src/hello_world_atomic.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include "bp_utils.h"
+/* CHANGEME for the number of cores under test */
+#define NUM_CORES 8
+volatile uint64_t core_num = 0;
+volatile uint64_t barrier = 0;
+
+int main(int argc, char** argv) {
+    uint64_t core_id;
+    uint64_t atomic_inc = 1;
+    uint64_t atomic_result = 0;
+
+    uint64_t print_addr = (uint64_t)(0x000000008FFFFFFF);
+    
+    __asm__ volatile("csrr %0, mhartid": "=r"(core_id): :);
+    
+    // synchronize with other cores and wait until it is this core's turn
+    while (core_num != core_id) { }
+    
+    // print out this core id
+    __asm__ volatile("sb %0, 0(%1)": : "r"(core_id), "r"(print_addr):);
+
+    // increment atomic counter
+    __asm__ volatile("amoadd.d %0, %2, (%1)": "=r"(atomic_result) 
+                                            : "r"(&core_num), "r"(atomic_inc)
+                                            :);
+    barrier_end(&barrier, NUM_CORES);
+
+    return 0;
+}
+

--- a/bp_common/test/src/demos/src/reloc_queue_demo.c
+++ b/bp_common/test/src/demos/src/reloc_queue_demo.c
@@ -1,3 +1,7 @@
+/*
+ * THIS DEMO IS NO LONGER SUPPORTED AND IS HERE ONLY FOR REFERENCE
+ */
+
 #include <stdint.h>
 
 #define QUEUE_LENGTH 32

--- a/bp_common/test/src/demos/src/start.S
+++ b/bp_common/test/src/demos/src/start.S
@@ -2,13 +2,24 @@
 .globl _start
 
 _start:
-/* setup stack pointer. Stacks start at 0x8FFF_DFFF */
-/* We then subtract off 4K*coreID */
+/* setup stack pointers. Stacks start at 0x8FFF_CFFF */
+/* We then subtract off 8K*coreID. The top 4K is for the core emulation stack
+ * the lower 4K is for the program TODO: Maybe larger stack value? */
     li   sp, 0x8FFFCFF0
-    
     csrr x1, mhartid 
+    slli x1, x1, 13
+    sub  sp, sp, x1
+
+/* save the stack pointer to mscratch, so it can be used on first trap entry*/
+    csrw mscratch, sp
+/* get 4K and subtract it off to get the program stack pointer */
+    li   x1, 1
     slli x1, x1, 12
     sub  sp, sp, x1 
+
+/* setup mtvec */ 
+   la x1, bp_mtvec_handler
+   csrw mtvec, x1
 
 /* 0 all registers */
     addi x1,  x0, 0
@@ -42,6 +53,7 @@ _start:
     addi x29, x0, 0
     addi x30, x0, 0
     addi x31, x0, 0
+
 
 /* jump to main */
     jal main


### PR DESCRIPTION
Added a basic test (hello_world_atomic) where cores use amoadd to increment a shared counter and print out their ID. Also made a version of the queue demo (atomic_queue_demo) that uses amoswap to lock the shared queue. Both of these were tested up to 8 cores.

This PR also include modifications to the start code to properly support multicore as every core needs its own emulation stack as well as program stack. The trap vector code was also modified to save stack pointers appropriately to reflect this change 
