### PR TITLE
CCE: fix lce data command for uncached data in normal execution mode

### DIFF
--- a/bp_me/src/v/cce/bp_cce_msg.v
+++ b/bp_me/src/v/cce/bp_cce_msg.v
@@ -365,7 +365,7 @@ module bp_cce_msg
       // Data is copied directly from MemDataResp
       // For uncached responses, only the least significant 64-bits will be valid
       lce_data_cmd.data = mem_data_resp.data;
-      if (mshr.flags[e_flag_sel_ucf] == e_lce_req_non_cacheable) begin
+      if (mem_data_resp.non_cacheable == e_lce_req_non_cacheable) begin
         lce_data_cmd.msg_type = e_lce_data_cmd_non_cacheable;
         lce_data_cmd.way_id = '0;
       end else begin


### PR DESCRIPTION
This change fixes a bug related to determining if the data message returning from memory is for a cached or uncached request. Basically, the current MSHR in the CCE is not guaranteed to be related to the returning memory data response so the CCE should instead examine the data response itself to form the proper LCE Data Command message.