### PR TITLE
Add mem_payload_width to bp_proc_params and fix CCE microcode to avoid deadlock in sync

### DIFF
--- a/bp_common/src/include/bp_common_aviary_defines.vh
+++ b/bp_common/src/include/bp_common_aviary_defines.vh
@@ -66,6 +66,8 @@ typedef struct packed
   integer instr_width;
   integer reg_addr_width;
   integer page_offset_width;
+
+  integer mem_payload_width;
 }  bp_proc_param_s;
 
 `define declare_bp_proc_params(bp_cfg_e_mp) \
@@ -104,7 +106,9 @@ typedef struct packed
   , localparam page_offset_width_p = proc_param_lp.page_offset_width                               \
                                                                                                    \
   , localparam vtag_width_p        = proc_param_lp.vaddr_width - proc_param_lp.page_offset_width   \
-  , localparam ptag_width_p        = proc_param_lp.paddr_width - proc_param_lp.page_offset_width
+  , localparam ptag_width_p        = proc_param_lp.paddr_width - proc_param_lp.page_offset_width   \
+                                                                                                   \
+  , localparam mem_payload_width_p = proc_param_lp.mem_payload_width
 
 `endif
 

--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -41,6 +41,8 @@ package bp_common_aviary_pkg;
       ,instr_width      : 32
       ,reg_addr_width   : 5
       ,page_offset_width: 12
+
+      ,mem_payload_width: 108
       };
 
   localparam bp_proc_param_s bp_single_core_cfg_p = 
@@ -75,6 +77,8 @@ package bp_common_aviary_pkg;
       ,instr_width      : 32
       ,reg_addr_width   : 5
       ,page_offset_width: 12
+
+      ,mem_payload_width: 108
       };
 
   localparam bp_proc_param_s bp_dual_core_cfg_p = 
@@ -109,6 +113,8 @@ package bp_common_aviary_pkg;
       ,instr_width      : 32
       ,reg_addr_width   : 5
       ,page_offset_width: 12
+
+      ,mem_payload_width: 110
       };
 
   localparam bp_proc_param_s bp_quad_core_cfg_p = 
@@ -143,6 +149,8 @@ package bp_common_aviary_pkg;
       ,instr_width      : 32
       ,reg_addr_width   : 5
       ,page_offset_width: 12
+
+      ,mem_payload_width: 112
       };
 
   localparam bp_proc_param_s bp_oct_core_cfg_p = 
@@ -177,6 +185,8 @@ package bp_common_aviary_pkg;
       ,instr_width      : 32
       ,reg_addr_width   : 5
       ,page_offset_width: 12
+
+      ,mem_payload_width: 114
       };
 
   localparam bp_proc_param_s bp_sexta_core_cfg_p =
@@ -211,6 +221,8 @@ package bp_common_aviary_pkg;
       ,instr_width      : 32
       ,reg_addr_width   : 5
       ,page_offset_width: 12
+
+      ,mem_payload_width: 116
       };
 
   typedef enum bit [lg_max_cfgs-1:0] 

--- a/bp_common/test/Makefile.frag
+++ b/bp_common/test/Makefile.frag
@@ -6,6 +6,7 @@ BP_DEMOS = \
   atomic_queue_demo_2 \
   atomic_queue_demo_4 \
   atomic_queue_demo_8 \
+  atomic_queue_demo_16 \
   queue_demo_2  \
   queue_demo_4  \
   queue_demo_8  \

--- a/bp_me/src/asm/microcode/cce/ei-tr.S
+++ b/bp_me/src/asm/microcode/cce/ei-tr.S
@@ -40,16 +40,20 @@ lce_inc: inc r0
 bi lce_top
 
 # send sync messages
+# r0 counts up from 0 number of sync messages sent
+# r1 holds constant N_LCE
+# r3 stores the constant SYNC_ACK to check response ack type against
+# The CCE waits for sync ack after each sync command. This avoids additional buffering being
+# required in the CCE, at a small "performance" cost during startup
 sync_init: movi 0 r0
 movi N_LCE r1
-sync_top: bge r0 r1 ack_top
+movi SYNC_ACK r3
+sync_top: bge r0 r1 ready
 pushq lceCmd SYNC r0
+popq lceResp
+bne r3 ackType error
 inc r0
 bi sync_top
-ack_top: bz r0 ready
-popq lceResp
-dec r0
-bi ack_top
 
 # Ready Routine
 ready: wfq lceReq

--- a/bp_me/src/asm/microcode/cce/ei.S
+++ b/bp_me/src/asm/microcode/cce/ei.S
@@ -40,18 +40,20 @@ lce_inc: inc r0
 bi lce_top
 
 # send sync messages
+# r0 counts up from 0 number of sync messages sent
+# r1 holds constant N_LCE
+# r3 stores the constant SYNC_ACK to check response ack type against
+# The CCE waits for sync ack after each sync command. This avoids additional buffering being
+# required in the CCE, at a small "performance" cost during startup
 sync_init: movi 0 r0
-movi SYNC_ACK r2
 movi N_LCE r1
-sync_top: bge r0 r1 ack_top
+movi SYNC_ACK r3
+sync_top: bge r0 r1 ready
 pushq lceCmd SYNC r0
+popq lceResp
+bne r3 ackType error
 inc r0
 bi sync_top
-ack_top: bz r0 ready
-popq lceResp
-bne r2 ackType error
-dec r0
-bi ack_top
 
 # Ready Routine
 # In ready state, the CCE can process lce responses, memory response, or new lce requests

--- a/bp_me/src/asm/microcode/cce/mesi-tr.S
+++ b/bp_me/src/asm/microcode/cce/mesi-tr.S
@@ -40,16 +40,20 @@ lce_inc: inc r0
 bi lce_top
 
 # send sync messages
+# r0 counts up from 0 number of sync messages sent
+# r1 holds constant N_LCE
+# r3 stores the constant SYNC_ACK to check response ack type against
+# The CCE waits for sync ack after each sync command. This avoids additional buffering being
+# required in the CCE, at a small "performance" cost during startup
 sync_init: movi 0 r0
 movi N_LCE r1
-sync_top: bge r0 r1 ack_top
+movi SYNC_ACK r3
+sync_top: bge r0 r1 ready
 pushq lceCmd SYNC r0
+popq lceResp
+bne r3 ackType error
 inc r0
 bi sync_top
-ack_top: bz r0 ready
-popq lceResp
-dec r0
-bi ack_top
 
 # Ready Routine
 ready: wfq lceReq

--- a/bp_me/src/asm/microcode/cce/mesi.S
+++ b/bp_me/src/asm/microcode/cce/mesi.S
@@ -40,18 +40,20 @@ lce_inc: inc r0
 bi lce_top
 
 # send sync messages
+# r0 counts up from 0 number of sync messages sent
+# r1 holds constant N_LCE
+# r3 stores the constant SYNC_ACK to check response ack type against
+# The CCE waits for sync ack after each sync command. This avoids additional buffering being
+# required in the CCE, at a small "performance" cost during startup
 sync_init: movi 0 r0
-movi SYNC_ACK r2
 movi N_LCE r1
-sync_top: bge r0 r1 ack_top
+movi SYNC_ACK r3
+sync_top: bge r0 r1 ready
 pushq lceCmd SYNC r0
+popq lceResp
+bne r3 ackType error
 inc r0
 bi sync_top
-ack_top: bz r0 ready
-popq lceResp
-bne r2 ackType error
-dec r0
-bi ack_top
 
 # Ready Routine
 # In ready state, the CCE can process lce responses, memory response, or new lce requests

--- a/bp_me/src/asm/microcode/cce/msi-tr.S
+++ b/bp_me/src/asm/microcode/cce/msi-tr.S
@@ -40,16 +40,20 @@ lce_inc: inc r0
 bi lce_top
 
 # send sync messages
+# r0 counts up from 0 number of sync messages sent
+# r1 holds constant N_LCE
+# r3 stores the constant SYNC_ACK to check response ack type against
+# The CCE waits for sync ack after each sync command. This avoids additional buffering being
+# required in the CCE, at a small "performance" cost during startup
 sync_init: movi 0 r0
 movi N_LCE r1
-sync_top: bge r0 r1 ack_top
+movi SYNC_ACK r3
+sync_top: bge r0 r1 ready
 pushq lceCmd SYNC r0
+popq lceResp
+bne r3 ackType error
 inc r0
 bi sync_top
-ack_top: bz r0 ready
-popq lceResp
-dec r0
-bi ack_top
 
 # Ready Routine
 ready: wfq lceReq

--- a/bp_me/src/asm/microcode/cce/msi.S
+++ b/bp_me/src/asm/microcode/cce/msi.S
@@ -40,18 +40,20 @@ lce_inc: inc r0
 bi lce_top
 
 # send sync messages
+# r0 counts up from 0 number of sync messages sent
+# r1 holds constant N_LCE
+# r3 stores the constant SYNC_ACK to check response ack type against
+# The CCE waits for sync ack after each sync command. This avoids additional buffering being
+# required in the CCE, at a small "performance" cost during startup
 sync_init: movi 0 r0
-movi SYNC_ACK r2
 movi N_LCE r1
-sync_top: bge r0 r1 ack_top
+movi SYNC_ACK r3
+sync_top: bge r0 r1 ready
 pushq lceCmd SYNC r0
+popq lceResp
+bne r3 ackType error
 inc r0
 bi sync_top
-ack_top: bz r0 ready
-popq lceResp
-bne r2 ackType error
-dec r0
-bi ack_top
 
 # Ready Routine
 # In ready state, the CCE can process lce responses, memory response, or new lce requests

--- a/bp_me/src/include/v/bp_cce_pkg.v
+++ b/bp_me/src/include/v/bp_cce_pkg.v
@@ -45,4 +45,7 @@ package bp_cce_pkg;
     ((2*`BSG_SAFE_CLOG2(num_lce_mp))+(3*`BSG_SAFE_CLOG2(lce_assoc_mp))+(2*paddr_width_mp) \
      +`bp_cce_coh_bits+`bp_cce_inst_num_flags+`bp_lce_cce_nc_req_size_width)
 
+  // MSHR width for BP is:
+  // 2*LOG(num_lce) + (9 + 78 + 2 + 15 + 2) = 2*LOG(num_lce) + 106
+
 endpackage : bp_cce_pkg

--- a/bp_me/src/v/cce/bp_cce.v
+++ b/bp_me/src/v/cce/bp_cce.v
@@ -107,6 +107,8 @@ module bp_cce
     assert (lce_sets_p > 1) else $error("Number of LCE sets must be greater than 1");
     assert (num_cce_p >= 1 && `BSG_IS_POW2(num_cce_p))
       else $error("Number of CCE must be power of two");
+    assert (mshr_width_lp == mem_payload_width_p)
+      else $error("MSHR width mismatch");
   end
   //synopsys translate_on
 

--- a/bp_me/src/v/cce/bp_cce_msg.v
+++ b/bp_me/src/v/cce/bp_cce_msg.v
@@ -365,7 +365,7 @@ module bp_cce_msg
       // Data is copied directly from MemDataResp
       // For uncached responses, only the least significant 64-bits will be valid
       lce_data_cmd.data = mem_data_resp.data;
-      if (mshr.flags[e_flag_sel_ucf] == e_lce_req_non_cacheable) begin
+      if (mem_data_resp.non_cacheable == e_lce_req_non_cacheable) begin
         lce_data_cmd.msg_type = e_lce_data_cmd_non_cacheable;
         lce_data_cmd.way_id = '0;
       end else begin

--- a/bp_me/src/v/cce/bp_cce_reg.v
+++ b/bp_me/src/v/cce/bp_cce_reg.v
@@ -42,8 +42,6 @@ module bp_cce_reg
       `bp_mem_cce_resp_width(paddr_width_p, mshr_width_lp)
     , localparam bp_mem_cce_data_resp_width_lp=
       `bp_mem_cce_data_resp_width(paddr_width_p, block_size_in_bits_lp, num_lce_p, lce_assoc_p)
-
-    , localparam bp_cce_mshr_width_lp=`bp_cce_mshr_width(num_lce_p, lce_assoc_p, paddr_width_p)
   )
   (input                                                                   clk_i
    , input                                                                 reset_i
@@ -54,7 +52,7 @@ module bp_cce_reg
    , input bp_lce_cce_resp_msg_type_e                                      null_wb_flag_i
    , input bp_lce_cce_ack_type_e                                           resp_ack_type_i
 
-   , input [bp_cce_mshr_width_lp-1:0]                                      mem_resp_payload_i
+   , input [mshr_width_lp-1:0]                                             mem_resp_payload_i
 
    , input [`bp_cce_inst_gpr_width-1:0]                                    alu_res_i
    , input [`bp_cce_inst_gpr_width-1:0]                                    mov_src_i
@@ -77,7 +75,7 @@ module bp_cce_reg
    , input                                                                 gad_cached_flag_i
 
    // Register value outputs
-   , output logic [bp_cce_mshr_width_lp-1:0]                               mshr_o
+   , output logic [mshr_width_lp-1:0]                                      mshr_o
 
    , output logic [`bp_cce_inst_num_gpr-1:0][`bp_cce_inst_gpr_width-1:0]   gpr_o
 

--- a/bp_top/src/v/bp_clint.v
+++ b/bp_top/src/v/bp_clint.v
@@ -13,16 +13,16 @@ module bp_clint
 
    , parameter dword_width_p = 64
 
-   , localparam cce_mshr_width_lp = `bp_cce_mshr_width(num_lce_p, lce_assoc_p, paddr_width_p)
+   , parameter mem_payload_width_p = "inv"
 
    , localparam mem_resp_width_lp=
-      `bp_mem_cce_resp_width(paddr_width_p,cce_mshr_width_lp)
+      `bp_mem_cce_resp_width(paddr_width_p,mem_payload_width_p)
    , localparam mem_data_resp_width_lp=
       `bp_mem_cce_data_resp_width(paddr_width_p,block_size_in_bits_p,num_lce_p,lce_assoc_p)
    , localparam mem_cmd_width_lp=
       `bp_cce_mem_cmd_width(paddr_width_p,num_lce_p,lce_assoc_p)
    , localparam mem_data_cmd_width_lp=
-      `bp_cce_mem_data_cmd_width(paddr_width_p,block_size_in_bits_p,cce_mshr_width_lp)
+      `bp_cce_mem_data_cmd_width(paddr_width_p,block_size_in_bits_p,mem_payload_width_p)
    )
   (input clk_i
    , input reset_i
@@ -68,7 +68,7 @@ module bp_clint
     , output [num_cce_p-1:0] timer_irq_o
    );
 
-`declare_bp_me_if(paddr_width_p,block_size_in_bits_p,num_lce_p,lce_assoc_p,cce_mshr_width_lp);
+`declare_bp_me_if(paddr_width_p,block_size_in_bits_p,num_lce_p,lce_assoc_p,mem_payload_width_p);
 
 bp_cce_mem_cmd_s [num_cce_p-1:0] mem_cmd_cast_i;
 bp_cce_mem_data_cmd_s [num_cce_p-1:0] mem_data_cmd_cast_i;

--- a/bp_top/src/v/bp_tile.v
+++ b/bp_top/src/v/bp_tile.v
@@ -13,8 +13,7 @@ module bp_tile
  import bsg_noc_pkg::*;
  #(parameter bp_cfg_e cfg_p = e_bp_inv_cfg
    `declare_bp_proc_params(cfg_p)
-   , localparam cce_mshr_width_lp = `bp_cce_mshr_width(num_lce_p, lce_assoc_p, paddr_width_p)
-   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, num_lce_p, lce_assoc_p, cce_mshr_width_lp)
+   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, num_lce_p, lce_assoc_p, mem_payload_width_p)
    `declare_bp_lce_cce_if_widths
      (num_cce_p, num_lce_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
 

--- a/bp_top/src/v/bp_top.v
+++ b/bp_top/src/v/bp_top.v
@@ -13,8 +13,7 @@ module bp_top
  import bsg_noc_pkg::*;
  #(parameter bp_cfg_e cfg_p = e_bp_inv_cfg
    `declare_bp_proc_params(cfg_p)
-   , localparam cce_mshr_width_lp = `bp_cce_mshr_width(num_lce_p, lce_assoc_p, paddr_width_p)
-   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, num_lce_p, lce_assoc_p, cce_mshr_width_lp)
+   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, num_lce_p, lce_assoc_p, mem_payload_width_p)
    `declare_bp_lce_cce_if_widths(num_cce_p
                                  ,num_lce_p
                                  ,paddr_width_p
@@ -88,7 +87,7 @@ module bp_top
   );
 
 `declare_bp_common_proc_cfg_s(num_core_p, num_cce_p, num_lce_p)
-`declare_bp_me_if(paddr_width_p, cce_block_width_p, num_lce_p, lce_assoc_p, cce_mshr_width_lp)
+`declare_bp_me_if(paddr_width_p, cce_block_width_p, num_lce_p, lce_assoc_p, mem_payload_width_p)
 `declare_bp_lce_cce_if(num_cce_p
                        ,num_lce_p
                        ,paddr_width_p
@@ -236,6 +235,7 @@ for(genvar i = 0; i < num_core_p; i++)
        ,.num_lce_p(num_lce_p)
        ,.block_size_in_bits_p(cce_block_width_p)
        ,.lce_assoc_p(lce_assoc_p)
+       ,.mem_payload_width_p(mem_payload_width_p)
        )
      clint
       (.clk_i(clk_i)


### PR DESCRIPTION
This contains two changes:
1. Add mem_payload_width_p to bp_proc_params struct that defines the size of payload field in the CCE-MEM interface to hold the CCE's MSHR. This keeps the payload size and contents opaque. The CCE casts the bits into the MSHR format used internally.

2. A small fix to CCE microcode to avoid deadlock during startup/sync. Previously, the LCE Response buffer could fill up if the number of LCEs was greater than the number of way groups managed by each CCE. This results in deadlock during the sync routine between the CCEs and LCEs. The CCE will now wait for the sync ack after each sync command. This adds some latency to the sync sequence at startup (only time it happens), but avoids having to double or quadruple the size of the LCE Response buffer at each CCE. The buffer is instead sized for the maximum number of response messages that could arrive during normal operation (i.e., after startup/sync)