### PR TITLE
Various fixes to CSR regfile 

### DIFF
--- a/bp_be/src/include/bp_be_csr_defines.vh
+++ b/bp_be/src/include/bp_be_csr_defines.vh
@@ -289,19 +289,19 @@ typedef struct packed
   // We don't currently have ASID support
   // We only support 39 bit physical address.
   // TODO: Generate this based on vaddr
-  logic [26:0] ppn;
+  logic [27:0] ppn;
 }  bp_satp_s;
 
 `define bp_satp_width ($bits(bp_satp_s))
 
 `define compress_satp_s(data_cast_mp) \
   bp_satp_s'{mode: data_cast_mp.mode[3]   \
-             ,ppn: data_cast_mp.ppn[26:0] \
+             ,ppn: data_cast_mp.ppn[27:0] \
              }
 
 `define decompress_satp_s(data_comp_mp) \
   rv64_satp_s'{mode: {data_comp_mp.mode, 3'b000} \
-               ,ppn: {17'h0, data_comp_mp.ppn}   \
+               ,ppn: {16'h0, data_comp_mp.ppn}   \
                ,default: '0                      \
                }
 
@@ -674,24 +674,30 @@ typedef struct packed
               }
 
 typedef logic [63:0] rv64_mtval_s;
-typedef logic [38:0] bp_mtval_s;
+typedef struct packed
+{
+  logic sgn;
+  logic [39:0] addr;
+}  bp_mtval_s;
 
 `define compress_mtval_s(data_cast_mp) \
-  data_cast_mp[0+:39]
+  bp_mtval_s'{sgn: data_cast_mp[39], addr: data_cast_mp[0+:40]}
 
 `define decompress_mtval_s(data_comp_mp) \
-  64'(data_comp_mp)
+  64'($signed(data_comp_mp))
 
 typedef logic [63:0] rv64_mepc_s;
-typedef logic [38:0] bp_mepc_s;
-
-`define bp_mepc_width ($bits(bp_mepc_s))
+typedef struct packed
+{
+  logic sgn;
+  logic [39:0] addr;
+}  bp_mepc_s;
 
 `define compress_mepc_s(data_cast_mp) \
-  data_cast_mp[0+:39]
+  bp_mepc_s'{sgn: data_cast_mp[39], addr: data_cast_mp[0+:40]} 
 
 `define decompress_mepc_s(data_comp_mp) \
-  64'(data_comp_mp)
+  64'($signed(data_comp_mp))
 
 typedef struct packed
 {
@@ -739,7 +745,7 @@ typedef bp_pmpcfg_s bp_pmpcfg0_s;
 
 typedef struct packed
 {
-  logic [9:0]  wpri;
+  logic [9:0]  warl;
   logic [53:0] addr_55_2;
 }  rv64_pmpaddr_s;
 
@@ -750,7 +756,7 @@ typedef rv64_pmpaddr_s rv64_pmpaddr3_s;
 
 typedef struct packed
 {
-  logic [36:0] addr_38_2;
+  logic [37:0] addr_39_2;
 }  bp_pmpaddr_s;
 
 typedef bp_pmpaddr_s bp_pmpaddr0_s;
@@ -759,10 +765,10 @@ typedef bp_pmpaddr_s bp_pmpaddr2_s;
 typedef bp_pmpaddr_s bp_pmpaddr3_s;
 
 `define compress_pmpaddr_s(data_cast_mp) \
-  bp_pmpaddr_s'{addr_38_2: data_cast_mp.addr_55_2[0+:37]}
+  bp_pmpaddr_s'{addr_39_2: data_cast_mp.addr_55_2[0+:38]}
 
 `define decompress_pmpaddr_s(data_comp_mp) \
-  rv64_pmpaddr_s'{addr_55_2: 54'(data_comp_mp.addr_38_2) \
+  rv64_pmpaddr_s'{addr_55_2: 54'(data_comp_mp.addr_39_2) \
                   ,default: '0                           \
                   }
 

--- a/bp_be/src/v/bp_be_checker/bp_be_checker_top.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_checker_top.v
@@ -80,10 +80,6 @@ module bp_be_checker_top
    , localparam vtag_width_lp     = (vaddr_width_p-bp_page_offset_width_gp)
    , localparam ptag_width_lp     = (paddr_width_p-bp_page_offset_width_gp)
    , localparam tlb_entry_width_lp = `bp_be_tlb_entry_width(ptag_width_lp)
-
-   // CSRs
-   , localparam mepc_width_lp  = `bp_mepc_width
-   , localparam mtvec_width_lp = `bp_mtvec_width
    )
   (input                              clk_i
    , input                            reset_i
@@ -131,8 +127,8 @@ module bp_be_checker_top
    , input                            trap_v_i
    , input                            ret_v_i
    , output [vaddr_width_p-1:0]       pc_o
-   , input [mtvec_width_lp-1:0]       tvec_i
-   , input [mepc_width_lp-1:0]        epc_i
+   , input [vaddr_width_p-1:0]        tvec_i
+   , input [vaddr_width_p-1:0]        epc_i
    , input                            tlb_fence_i
    
    //iTLB fill interface

--- a/bp_be/src/v/bp_be_checker/bp_be_director.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.v
@@ -63,10 +63,6 @@ module bp_be_director
    , localparam vtag_width_lp     = (vaddr_width_p-bp_page_offset_width_gp)
    , localparam ptag_width_lp     = (paddr_width_p-bp_page_offset_width_gp)
    , localparam tlb_entry_width_lp = `bp_be_tlb_entry_width(ptag_width_lp)
-
-   // CSRs
-   , localparam mepc_width_lp  = `bp_mepc_width
-   , localparam mtvec_width_lp = `bp_mtvec_width
    )
   (input                               clk_i
    , input                             reset_i
@@ -96,8 +92,8 @@ module bp_be_director
    , input                            trap_v_i
    , input                            ret_v_i
    , output [vaddr_width_p-1:0]       pc_o 
-   , input [mepc_width_lp-1:0]        tvec_i
-   , input [mtvec_width_lp-1:0]       epc_i
+   , input [vaddr_width_p-1:0]        tvec_i
+   , input [vaddr_width_p-1:0]        epc_i
    , input                            tlb_fence_i
    
    //iTLB fill interface

--- a/bp_be/src/v/bp_be_mem/bp_be_csr.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_csr.v
@@ -10,8 +10,6 @@ module bp_be_csr
     , localparam csr_cmd_width_lp = `bp_be_csr_cmd_width
     , localparam ecode_dec_width_lp = `bp_be_ecode_dec_width
 
-    , localparam mepc_width_lp  = `bp_mepc_width
-    , localparam mtvec_width_lp = `bp_mtvec_width
     , localparam satp_width_lp  = `bp_satp_width
 
     , localparam hartid_width_lp = `BSG_SAFE_CLOG2(num_core_p)
@@ -46,8 +44,8 @@ module bp_be_csr
     , output [rv64_priv_width_gp-1:0]   priv_mode_o
     , output logic                      trap_v_o
     , output logic                      ret_v_o
-    , output logic [mepc_width_lp-1:0]  epc_o
-    , output logic [mtvec_width_lp-1:0] tvec_o
+    , output logic [vaddr_width_p-1:0]  epc_o
+    , output logic [vaddr_width_p-1:0]  tvec_o
     , output [satp_width_lp-1:0]        satp_o
     , output                            translation_en_o
     , output logic                      tlb_fence_o
@@ -402,8 +400,10 @@ always_comb
           mstatus_n.spie      = mstatus_r.sie;
           mstatus_n.sie       = 1'b0;
 
-          sepc_n              = exception_pc_i;
-          stval_n             = exception_ecode_dec_cast_i.illegal_instr ? exception_instr_i : exception_vaddr_i;
+          sepc_n              = paddr_width_p'($signed(exception_pc_i));
+          stval_n             = exception_ecode_dec_cast_i.illegal_instr 
+                                ? exception_instr_i 
+                                : paddr_width_p'($signed(exception_vaddr_i));
 
           scause_n._interrupt = 1'b0;
           scause_n.ecode      = exception_ecode_li;
@@ -418,8 +418,10 @@ always_comb
           mstatus_n.mpie      = mstatus_r.mie;
           mstatus_n.mie       = 1'b0;
 
-          mepc_n              = exception_pc_i;
-          mtval_n             = exception_ecode_dec_cast_i.illegal_instr ? exception_instr_i : exception_vaddr_i;
+          mepc_n              = paddr_width_p'($signed(exception_pc_i));
+          mtval_n             = exception_ecode_dec_cast_i.illegal_instr 
+                                ? exception_instr_i 
+                                : paddr_width_p'($signed(exception_vaddr_i));
 
           mcause_n._interrupt = 1'b0;
           mcause_n.ecode      = exception_ecode_li;
@@ -436,7 +438,9 @@ always_comb
           mstatus_n.spie      = mstatus_r.sie;
           mstatus_n.sie       = 1'b0;
 
-          sepc_n              = (exception_v_i & exception_ecode_v_li) ? exception_pc_i : 64'(interrupt_pc_i);
+          sepc_n              = (exception_v_i & exception_ecode_v_li) 
+                                ? paddr_width_p'($signed(exception_pc_i))
+                                : paddr_width_p'($signed(interrupt_pc_i));
           stval_n             = '0;
           scause_n._interrupt = 1'b1;
           scause_n.ecode      = exception_icode_li;
@@ -451,7 +455,9 @@ always_comb
           mstatus_n.mpie      = mstatus_r.mie;
           mstatus_n.mie       = 1'b0;
 
-          mepc_n              = (exception_v_i & exception_ecode_v_li) ? exception_pc_i : 64'(interrupt_pc_i);
+          mepc_n              = (exception_v_i & exception_ecode_v_li) 
+                                ? paddr_width_p'($signed(exception_pc_i))
+                                : paddr_width_p'($signed(interrupt_pc_i));
           mtval_n             = '0;
           mcause_n._interrupt = 1'b1;
           mcause_n.ecode      = exception_icode_li;

--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -46,10 +46,6 @@ module bp_be_mem_top
    
    // VM
    , localparam tlb_entry_width_lp = `bp_be_tlb_entry_width(ptag_width_p)
-
-   // CSRs
-   , localparam mepc_width_lp  = `bp_mepc_width
-   , localparam mtvec_width_lp = `bp_mtvec_width
    )
   (input                                     clk_i
    , input                                   reset_i
@@ -113,8 +109,8 @@ module bp_be_mem_top
    , output [rv64_priv_width_gp-1:0]         priv_mode_o
    , output                                  trap_v_o
    , output                                  ret_v_o
-   , output [mepc_width_lp-1:0]              epc_o
-   , output [mtvec_width_lp-1:0]             tvec_o
+   , output [vaddr_width_p-1:0]              epc_o
+   , output [vaddr_width_p-1:0]              tvec_o
    , output                                  tlb_fence_o
    );
 

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -35,10 +35,6 @@ module bp_be_top
    , localparam vtag_width_lp     = (vaddr_width_p-bp_page_offset_width_gp)
    , localparam ptag_width_lp     = (paddr_width_p-bp_page_offset_width_gp)
    , localparam tlb_entry_width_lp = `bp_be_tlb_entry_width(ptag_width_lp)
-
-   // CSRs
-   , localparam mepc_width_lp  = `bp_mepc_width
-   , localparam mtvec_width_lp = `bp_mtvec_width
    )
   (input                                     clk_i
    , input                                   reset_i
@@ -125,9 +121,9 @@ bp_be_calc_status_s    calc_status;
 logic chk_dispatch_v, chk_poison_iss, chk_poison_isd;
 logic chk_poison_ex1, chk_poison_ex2, chk_roll, chk_instr_dequeue_v;
 
-logic [mtvec_width_lp-1:0] chk_tvec_li;
-logic [mepc_width_lp-1:0]  chk_epc_li;
-logic [vaddr_width_p-1:0]  chk_pc_lo;
+logic [vaddr_width_p-1:0] chk_tvec_li;
+logic [vaddr_width_p-1:0] chk_epc_li;
+logic [vaddr_width_p-1:0] chk_pc_lo;
 
 logic chk_trap_v_li, chk_ret_v_li, chk_tlb_fence_li, chk_ifence_li;
 

--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -15,7 +15,7 @@ package bp_common_aviary_pkg;
       ,num_lce: 1
 
       ,vaddr_width: 39
-      ,paddr_width: 39
+      ,paddr_width: 40
       ,asid_width : 1
       
       ,branch_metadata_fwd_width: 27
@@ -65,7 +65,7 @@ package bp_common_aviary_pkg;
       ,num_lce: 2
 
       ,vaddr_width: 39
-      ,paddr_width: 39
+      ,paddr_width: 40
       ,asid_width : 1
       
       ,branch_metadata_fwd_width: 27
@@ -115,7 +115,7 @@ package bp_common_aviary_pkg;
       ,num_lce: 4
       
       ,vaddr_width: 39
-      ,paddr_width: 39
+      ,paddr_width: 40
       ,asid_width : 1
       
       ,branch_metadata_fwd_width: 27
@@ -165,7 +165,7 @@ package bp_common_aviary_pkg;
       ,num_lce: 8
       
       ,vaddr_width: 39
-      ,paddr_width: 39
+      ,paddr_width: 40
       ,asid_width : 1
       
       ,branch_metadata_fwd_width: 27
@@ -215,7 +215,7 @@ package bp_common_aviary_pkg;
       ,num_lce: 16
       
       ,vaddr_width: 39
-      ,paddr_width: 39
+      ,paddr_width: 40
       ,asid_width : 1
       
       ,branch_metadata_fwd_width: 27
@@ -265,7 +265,7 @@ package bp_common_aviary_pkg;
       ,num_lce: 32
 
       ,vaddr_width: 39
-      ,paddr_width: 39
+      ,paddr_width: 40
       ,asid_width : 1
 
       ,branch_metadata_fwd_width: 27


### PR DESCRIPTION
- Changing pmpaddr to warl to match spec.  
- Changing physical address space to 40 bits to increase mmio range and suss out issues of vaddr/paddr mismatch.  
- Changing mepc/mtval/mtvec storage to honor sign extension for virtual addresses and zero extension for zero extended written values.