### PR TITLE
Making itlb writes unconditional

### DIFF
--- a/bp_common/syn/Makefile.vcs
+++ b/bp_common/syn/Makefile.vcs
@@ -19,7 +19,7 @@ VCS_BUILD_OPTS += -CFLAGS "-I$(BP_EXTERNAL_DIR)/include -std=c++11"
 VCS_BUILD_OPTS += -LDFLAGS "-L$(BP_EXTERNAL_DIR)/lib -ldramsim -Wl,-rpath=$(BP_EXTERNAL_DIR)/lib"
 VCS_BUILD_OPTS += -assert svaext
 VCS_BUILD_OPTS += +lint=TFIPC-L
-VCS_BUILD_OPTS += -debug_pp
+VCS_BUILD_OPTS += -debug_all
 
 LINT_OPTIONS = +lint=all,noSVA-UA,noSVA-NSVU,noNS,noVCDE
 

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -24,7 +24,7 @@ module bp_fe_mem
 
    , input [mem_cmd_width_lp-1:0]                     mem_cmd_i
    , input                                            mem_cmd_v_i
-   , output                                           mem_cmd_ready_o
+   , output                                           mem_cmd_yumi_o
 
    , input                                            mem_poison_i
 
@@ -57,11 +57,11 @@ assign mem_cmd_cast_i = mem_cmd_i;
 assign mem_resp_o     = mem_resp_cast_o;
 
 logic instr_access_fault_lo, icache_miss_lo, itlb_miss_lo;
-logic itlb_ready_lo;
+logic icache_ready_lo;
 
 wire itlb_fence_v = mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_tlb_fence);
 wire itlb_fill_v  = mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_tlb_fill);
-wire fetch_v      = mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_fetch);
+wire fetch_v      = mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_fetch) & icache_ready_lo;
 
 bp_fe_tlb_entry_s itlb_r_entry;
 logic itlb_r_v_lo;
@@ -87,7 +87,6 @@ wire                    uncached_li = itlb_r_entry.uc;
 wire [ptag_width_p-1:0] ptag_li     = itlb_r_entry.ptag;
 wire                    ptag_v_li   = itlb_r_v_lo;
 
-logic                     icache_ready_lo;
 logic [instr_width_p-1:0] icache_data_lo;
 logic                     icache_data_v_lo;
 bp_fe_icache 
@@ -134,25 +133,18 @@ bp_fe_icache
    ,.lce_resp_ready_i(lce_resp_ready_i)
    );
 
-// We don't need to check itlb ready, because it is only ready when not writing.  
-//   Reads and writes to itlb are mutually exclusive by construction
-assign mem_cmd_ready_o = icache_ready_lo;
+assign mem_cmd_yumi_o = itlb_fence_v | itlb_fill_v | fetch_v;
 
-always_ff @(negedge clk_i)
-  begin
-    assert(mem_cmd_ready_o || ~mem_cmd_v_i);
-  end
-
-logic mem_cmd_v_r, mem_cmd_v_rr;
+logic fetch_v_r, fetch_v_rr;
 logic itlb_miss_r;
 always_ff @(posedge clk_i)
   begin
-    itlb_miss_r  <= itlb_miss_lo;
-    mem_cmd_v_r  <= mem_cmd_v_i;
-    mem_cmd_v_rr <= mem_cmd_v_r & ~mem_poison_i;
+    itlb_miss_r <= itlb_miss_lo;
+    fetch_v_r   <= fetch_v;
+    fetch_v_rr  <= fetch_v_r & ~mem_poison_i;
   end
 
-assign mem_resp_v_o    = mem_resp_ready_i & mem_cmd_v_rr;
+assign mem_resp_v_o    = mem_resp_ready_i & fetch_v_rr;
 assign mem_resp_cast_o = '{instr_access_fault: instr_access_fault_lo
                            ,itlb_miss        : itlb_miss_r
                            ,icache_miss      : icache_miss_lo

--- a/bp_fe/src/v/bp_fe_pc_gen.v
+++ b/bp_fe/src/v/bp_fe_pc_gen.v
@@ -24,7 +24,7 @@ module bp_fe_pc_gen
  
    , output [mem_cmd_width_lp-1:0]                   mem_cmd_o
    , output                                          mem_cmd_v_o
-   , input                                           mem_cmd_ready_i
+   , input                                           mem_cmd_yumi_i
 
    , output                                          mem_poison_o
 
@@ -75,6 +75,7 @@ wire [vaddr_width_p-1:0] pc_if1 = pc_gen_stage_r[0].pc;
 wire [vaddr_width_p-1:0] pc_if2 = pc_gen_stage_r[1].pc;
 
 // Flags for valid FE commands
+wire fetch_v          = mem_cmd_yumi_i & (mem_cmd_cast_o.op == e_fe_op_fetch);
 wire state_reset_v    = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_state_reset); 
 wire pc_redirect_v    = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_pc_redirection);
 wire itlb_fill_v      = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_itlb_fill_response);
@@ -151,14 +152,7 @@ always_ff @(posedge clk_i)
 
 always_comb
   begin
-    // We can't fetch from wait state, only run and coming out of stall.
-    // We wait until both the FE queue and I$ are ready, but flushes invalidate the fetch.
-    // The next PC is valid during a FE cmd, since it is a non-speculative
-    //   command and we must accept it immediately.
-    // This may cause us to fetch during an I$ miss or a with a full queue.  
-    // FE cmds normally flush the queue, so we don't expect this to affect
-    //   power much in practice.
-    pc_gen_stage_n[0].v          = ~is_wait & (cmd_nonattaboy_v || (fe_queue_ready_i & mem_cmd_ready_i & ~flush));
+    pc_gen_stage_n[0].v          = fetch_v;
     pc_gen_stage_n[0].pred_taken = btb_br_tgt_v_lo | ovr_taken;
     pc_gen_stage_n[0].ovr        = ovr_taken | ovr_ntaken;
 
@@ -279,7 +273,14 @@ assign ovr_taken  = pc_gen_stage_r[1].v & ~pc_gen_stage_r[0].ovr & ~pc_gen_stage
 assign ovr_ntaken = pc_gen_stage_r[1].v & ~pc_gen_stage_r[0].ovr &  pc_gen_stage_r[0].pred_taken &  (is_br & ~bht_pred_lo);
 assign br_target  = pc_gen_stage_r[1].pc + scan_instr.imm;
 
-assign mem_cmd_v_o = mem_cmd_ready_i & (itlb_fence_v | itlb_fill_v | pc_gen_stage_n[0].v);
+// We can't fetch from wait state, only run and coming out of stall.
+// We wait until both the FE queue and I$ are ready, but flushes invalidate the fetch.
+// The next PC is valid during a FE cmd, since it is a non-speculative
+//   command and we must accept it immediately.
+// This may cause us to fetch during an I$ miss or a with a full queue.  
+// FE cmds normally flush the queue, so we don't expect this to affect
+//   power much in practice.
+assign mem_cmd_v_o = cmd_nonattaboy_v || (~is_wait & fe_queue_ready_i & ~flush); 
 always_comb
   begin
     mem_cmd_cast_o = '0;

--- a/bp_fe/src/v/bp_fe_top.v
+++ b/bp_fe/src/v/bp_fe_top.v
@@ -56,7 +56,7 @@ module bp_fe_top
 `declare_bp_fe_mem_structs(vaddr_width_p, lce_sets_p, cce_block_width_p, vtag_width_p, ptag_width_p)
    
 bp_fe_mem_cmd_s  mem_cmd_lo;
-logic            mem_cmd_v_lo, mem_cmd_ready_li;
+logic            mem_cmd_v_lo, mem_cmd_yumi_li;
 logic            mem_poison_lo;
 bp_fe_mem_resp_s mem_resp_li;
 logic            mem_resp_v_li, mem_resp_ready_lo;
@@ -69,7 +69,7 @@ bp_fe_pc_gen
                
    ,.mem_cmd_o(mem_cmd_lo)
    ,.mem_cmd_v_o(mem_cmd_v_lo)
-   ,.mem_cmd_ready_i(mem_cmd_ready_li)
+   ,.mem_cmd_yumi_i(mem_cmd_yumi_li)
 
    ,.mem_poison_o(mem_poison_lo)
 
@@ -102,7 +102,7 @@ bp_fe_mem
 
    ,.mem_cmd_i(mem_cmd_lo)
    ,.mem_cmd_v_i(mem_cmd_v_lo)
-   ,.mem_cmd_ready_o(mem_cmd_ready_li)
+   ,.mem_cmd_yumi_o(mem_cmd_yumi_li)
 
    ,.mem_poison_i(mem_poison_lo)
 


### PR DESCRIPTION
while having fetches depend on icache_ready.  Because the fe_mem will conditionally accept the command, it needs to be valid-yumi instead of ready-valid.  This incurs no additional hardware cost, because pc_gen is already helpful, due to the wait state.

Give this a shot in Linux run before we merge it in, but it's passing regression locally