### PR TITLE
Update documentation for release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,24 @@
-By submitting code to this repository, you agree that 
-it will be subject to the open source license selected
-by Michael Taylor for the project.
+Copyright (c) 2019, University of Washington
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the University of Washington nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL UNIVERSITY OF WASHINGTON BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ The next release of BlackParrot, v1.0, is coming in September 2019, and will con
 Coming soon!
 
 # BlackParrot interface specification
-Coming soon!
+BlackParrot is an aggresively modular design: communication between the components is performed over a set of narrow
+interfaces. The interfaces are designed to allow implementations of the FE, BE or ME to change
+independently of one another.
+
+[Interface specification](docs/InterfaceSpecification.md)
 
 # BlackParrot microarchitectural specification
 Coming soon!

--- a/bp_common/src/include/bp_common_fe_be_if.vh
+++ b/bp_common/src/include/bp_common_fe_be_if.vh
@@ -176,11 +176,7 @@
  */
 `define declare_bp_fe_be_if_widths(vaddr_width_mp, paddr_width_mp, asid_width_mp, branch_metadata_fwd_width_mp) \
   , localparam fe_queue_width_lp=`bp_fe_queue_width(vaddr_width_mp,branch_metadata_fwd_width_mp) \
-  , localparam fe_cmd_width_lp=`bp_fe_cmd_width(vaddr_width_mp                                   \
-                                                ,paddr_width_mp                                  \
-                                                ,asid_width_mp                                   \
-                                                ,branch_metadata_fwd_width_mp                    \
-                                                )
+  , localparam fe_cmd_width_lp=`bp_fe_cmd_width(vaddr_width_mp, paddr_width_mp, asid_width_mp, branch_metadata_fwd_width_mp)
 
 /*
  * bp_fe_queue_s can either contain an instruction or exception.

--- a/bp_common/src/include/bp_common_me_if.vh
+++ b/bp_common/src/include/bp_common_me_if.vh
@@ -340,21 +340,8 @@ typedef enum bit [2:0]
    +paddr_width_mp+cce_block_width_mp)
 
 `define declare_bp_lce_cce_if_widths(num_cce_mp, num_lce_mp, paddr_width_mp, lce_assoc_mp, data_width_mp, cce_block_width_mp) \
-    , localparam lce_cce_req_width_lp=`bp_lce_cce_req_width(num_cce_mp                         \
-                                                            ,num_lce_mp                        \
-                                                            ,paddr_width_mp                    \
-                                                            ,data_width_mp                     \
-                                                            )                                  \
-    , localparam lce_cce_resp_width_lp=`bp_lce_cce_resp_width(num_cce_mp                       \
-                                                              ,num_lce_mp                      \
-                                                              ,paddr_width_mp                  \
-                                                              ,cce_block_width_mp              \
-                                                              )                                \
-    , localparam lce_cmd_width_lp=`bp_lce_cmd_width(num_lce_mp                                 \
-                                                    ,lce_assoc_mp                              \
-                                                    ,paddr_width_mp                            \
-                                                    ,cce_block_width_mp                        \
-                                                    )
-
+    , localparam lce_cce_req_width_lp=`bp_lce_cce_req_width(num_cce_mp, num_lce_mp, paddr_width_mp, data_width_mp)        \
+    , localparam lce_cce_resp_width_lp=`bp_lce_cce_resp_width(num_cce_mp, num_lce_mp, paddr_width_mp, cce_block_width_mp) \
+    , localparam lce_cmd_width_lp=`bp_lce_cmd_width(num_lce_mp, lce_assoc_mp, paddr_width_mp, cce_block_width_mp)
 
 `endif

--- a/docs/interface_specification.md
+++ b/docs/interface_specification.md
@@ -1,0 +1,120 @@
+# FE-BE Interfaces
+
+The Front End and Back End communicate using FIFO queues. There will be an unambiguous and uniform policy for priority between queues. The number of queues is minimized subject to correct functionality, to reduce the complexity of the interface. The Front End Queue sends information from the Front End to the Back End. The Command Queue sends information from the Back End to the Front End. All “true” architectural state lives in the backend, but the front end may have shadow state.
+
+Logically, the BE controls the FE and may command the FE to flush all state, redirect the PC, etc. The FE uses its queue to supply the BE with (possibly speculative) instruction/PC pairs and inform the BE of any exceptions that have occurred within the unit (e.g., misaligned instruction fetch) so the BE may ensure all exceptions are taken precisely. The BE checks the PC in the instruction/PC pairs to make sure that the FE’s predictions correspond to correct architectural execution.  On reset, the FE shall be in a quiescent state; not fetching.
+
+If a queue is full, the unit wishing to send data should stall until a new entry can be enqueued in the appropriate queue to prevent information loss. The handshake shall conform to one of the three [BaseJump STL](http://cseweb.ucsd.edu/~mbtaylor/papers/Taylor\_DAC\_BaseJump\_STL\_2018.pdf) handshakes, most likely valid->ready on the consumer side, and ready->valid on the input. The queues shall be implemented with one of the BaseJump STL queue implementations. Each block is responsible for only issuing operations (e.g., translation requests, cache access, instruction execution, etc.) if it is capable of storing any possible exception information for that operation.
+
+# FE->BE (fe\_queue)
+- Description: Front End Queue (FIFO) passes bp\_fe\_queue\_s comprising a message type and the message data:
+  - bp\_fe\_fetch\_s
+  - bp\_fe\_exception\_s
+- Interface:
+  - BaseJump STL valid->ready on consumer and ready->valid on producer
+  - The FE Queue must support a clear operation (to support mispredicts)
+- bp\_fe\_fetch\_s
+  - 39-bit PC (virtual address)
+  - 32-bit instruction data
+    - Invariant; although the PC may be speculative, the value of _instruction_ is correct for that PC. We make similar assertions for the itlb; the itlb mappings made by the FE are not speculative; they are required to be correct at all times.
+  - branch prediction metadata bp\_fe\_branch\_metadata\_fwd\_s.
+    - This structure is for the branch predictor to update its internal data structures based on feedback from the BE as to whether this particular PC/instruction pair was correct. The BE does not look at the metadata, since this would mean that the BE implementation is tightly coupled to the front end implementation. This would be the opposite of our intended separation of the three components (BE,FE,ME) via a clean interface. The backend knows that the frontend has made a incorrect prediction because it was sent an incorrect PC in the FE queue.
+  - Typically this structure includes a pointer back to the original state that made the prediction; for example an index into a branch history table; or a field indicating whether the prediction came from BTB, BHT, or RAS (return address stack). All of these are private to the predictor and forwarded along by the BE.
+  - An example two-bit saturating counter branch prediction implementation, where high bit indicates the predicted direction, and the low bit indicates if the prediction is weak:
+    - bp\_fe\_branch\_metadata\_fwd\_s (only defined in FE)
+    - oldval: 2-bit state bits read from the branch history table (BHT)
+    - index: index of entry in branch history table
+    - If the FE cmd queue receives an attaboy, then it will perform the following operation :   
+    - BHT[index] <= { oldval[1], 1’b0 };
+    - We write back the predicted direction, and make it a strong prediction.
+    - If the FE cmd queue receives a mispredict, then it will perform the following operation:
+    - BHT[index] =  { oldval[1] ^ oldval[0], 1’b1 }
+    - We flip the predicted direction if it was a weak prediction last time. Any prediction after a misprediction is a weak prediction. 
+    - The branch prediction metadata should be associated with an incorrect PC that has been presented to the front end, rather than the instruction that generated that PC, since these could be arbitrarily separated in microarchitectural time (via icache or TLB) and will increase complexity.
+  - Future possible extensions (or non-features for this version.)
+    - K-bit HART ID for multithreading. For now, we hold off on this, as we generally don’t want to add interfaces we don’t support. 
+    - Process ID, Address Space ID, or thread ID (is this needed?) 
+    - If any of these things are actually ISA concepts, seems like the best thing is to just say that the fetch unit must be flushed to prevent co-existence of these items, eliminating the need to disambiguate between them.
+- bp\_fe\_exception\_s
+  - Exceptions should be serviced inline with instructions. Otherwise we have no way of knowing if this exception is eclipsed by a preceding branch mispredict. Every instruction has a PC so that field can be reused. We can carry a bit-vector along inside bp\_fe\_fetch\_s to indicate these exceptions and/or other status information. FE does not receive interrupts, but may raise exceptions.
+  - 39-bit virtual PC causing the exception (should be aligned with PC bp\_fe\_queue\_s)
+    - Specifies the PC of the illegal instruction, or the address (PC) causing exceptions.
+  - Exception Code (cause)
+    - In order of priority:
+    - Instruction Address Misaligned
+      - This has priority over a TLB miss because a itlb miss can have a side-effect, and presumably a misaligned instruction is a sign of anomalous execution.
+    - itlb miss 
+      - Page table walking can not occur in front end, because it writes the A bit in the page table entries; which means the instruction cache would have to support writes. Moreover, this bit is an architectural side effect, and is not allowed to be set speculatively. Only the backend can precisely commit architectural side-effects. For these reasons, itlb misses are handled by the backend.
+    - This may also occur if translation is disabled. In this case, a itlb means that the physical page is not in the itlb and we don’t have the PMP/PMA information cached. The BE will not perform a page walk in this case; it will just return the PMP/PMA information.
+    - Instruction access faults (i.e. permissions) must be checked by the FE because the interpretation of the L and X bits are determined by whether the system is in M mode or S and U mode. These bits will be stored in the itlb.
+Illegal Instruction
+  - Future possible extensions (or non-features for this version.)
+    - Support for multiple fetch entries in a single packet. Only useful for multiple-issue BE implementations.
+
+# BE->FE (fe\_cmd)
+- Description: FE Command Queue (fe\_cmd) sends the following commands from the Back End to the Front End, using a single command queue containing structures of type bp\_fe\_cmd\_s. From the perspective of architectural and microarchitectural state, enqueuing a command onto the command queue is beyond the point of no return, although the side-effects are not guaranteed until after the fence line goes high. With the exception of the attaboy commands, the BE will not enqueue additional commands until all prior commands have been processed. The FE must dequeue attaboys immediately upon reception and should process other commands as quickly as possible. However, due to the fence line it is not an invariant that the FE processes other instructions within a single cycle. The Command Queue shall transmit a union data structure, bp\_fe\_cmd\_s which contains opcodes and operands.
+- Interface
+  - The FIFO should not need to support a clear operation (except for via a full reset), all things enqueued must be processed.
+  - The FIFO should have a fence wire to indicate if all items have been absorbed from the FIFO, & all commands have been processed. Depending on implementation, the fence wire may be asserted multiple cycles after the FIFO is actually empty.
+  - Commands that feature PC redirection or shadow state change will flush the FE Queue. The BE of the processor will wait on the FE cmd queue’s fence wire before reading new items from the FE queue or enqueing new items on the command queue.
+- Available Commands
+  - State reset
+    - Standard operands
+      - PC virtual address
+    - Used after reset, or after coming out of power gating
+    - Flush / invalidate all state
+      - Instruction/Exception pipeline
+      - itlb
+      - L1 I$
+      - Shadow U/S/M bit
+      - ASIDs
+    - Reset PC to X
+  - PC redirection
+    - Standard operands
+      - PC virtual address
+    - Subopcodes
+      - URET, SRET, MRET
+        - These return from a trap and will contain the PC to return to. They set the shadow privilege mode in the FE.  This is done because the EPC is architectural state and lives in the BE, but we want to track this to avoid speculative access of state (instruction cache line) that is guarded by a protection boundary.
+      - Interrupt (no-fault PC redirection)
+      - Branch mispredict (at-fault PC redirection)
+        - In this case, the PC is the corrected target PC, not the PC of the branch
+        - bp_fe_branch_metadata_fwd_s
+        - Misprection reason (not a branch, wrong direction)
+      - Trap (at-fault PC redirection, with potential change of permissions)
+      - Context switch (no-fault PC redirection to new address space; see satp register)
+        - ASID
+        - Translation enabled / disabled
+      - Simple FE implementations which do not track the ASID for each TLB entry will also perform an itlb fence operation, flushing the itlb.
+      - More complex FE implementations will register the new ASID and not perform an itlb fence.
+  - Icache fence
+    - If icache is coherent with dcache, flush the icache pipeline.
+    - Else, flush the icache pipeline and the icache as well.
+  - Attaboy (no PC redirection, contains branch pred feedback information corresponding to correct prediction
+    - bp\_fe\_branch\_metadata\_fwd\_s
+  - Itlb fill response
+    - Contains the information necessary to populate an itlb translation.
+    - Standard operands:
+      - PC virtual address
+        - If translation is disabled, this will actually be a physical address
+      - Page table entry leaf subfields
+        - Physical address
+        - Extent
+        - U bit (user or supervisor)
+          - Each page is executable by user or supervisor, but not both
+        - G bit (global bit)
+          - Protects entries from invalidation by sfence.VMA if they have ASID=0
+        - L,X bits (PMP metadata)
+      - Non-operands
+        - D,W,R,V bits. The RSW field is unused.
+    - Notes
+      - The FE uses its own heuristics to decide what to evict
+      - Eviction does not require writeback of information
+  - Itlb fence
+    - Issued upon sfence.VMA commit or when PMA/PMP bits are modified
+    - Standard operands:
+      - Virtual address
+      - asid
+      - All addresses flag
+      - All asid flag
+    - A simple implementation will flush the entire itlb
+


### PR DESCRIPTION
This is the branch we're going to use to update documentation prior to v1.0.  Let's discuss what's all necessary and push to this branch over the next week.

First thing @muwyse, could you write up the current LCE-CCE interface? The version in the Interface Specification doc is out of date (still refers to data_cmd and data_resp).  Probably just a list of what each command does and then a few examples of sequences (cache fill routine, invalidation).

- [ ] Update interface_specification with LCE-CCE IF
- [ ] FE diagrams
- [ ] BE diagrams
- [ ] ME diagrams
- [ ] Top level diagrams
- [ ] Add repo guide (parameterized structs, aviary configurations, pointers to tapeouts)
- [ ] Document SDK (bp_finish, bp_print, how to add a test)
- [ ] Fix up test code / demos so that they all terminate
- [ ] Clean code and document inline (we should code review for this)

