### PR TITLE
fix LR not issuing as write miss when block not cached

### DIFF
--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -468,7 +468,8 @@ module bp_be_dcache
   logic load_reserved_v_r;
 
   // Upgrade if a load reserved and we don't have the line in exclusive state
-  assign lr_miss_tv = v_tv_r & lr_op_tv_r & load_hit & ~store_hit;
+  // Load reserved misses if not in exclusive or modified (whether load hit or not)
+  assign lr_miss_tv = v_tv_r & lr_op_tv_r & ~store_hit;
   // Succeed if the address matches and we have a store hit
   assign sc_success  = v_tv_r & sc_op_tv_r & store_hit & load_reserved_v_r 
                        & (load_reserved_tag_r == addr_tag_tv)

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v
@@ -156,20 +156,22 @@ module bp_be_dcache_lce_req
       // READY
       // wait for the cache miss.
       e_READY: begin
-        if (load_miss_i | store_miss_i) begin
+        // LR needs priority over regular load miss, otherwise it might get sent out as a regular
+        // load miss if the cache block is not in the cache at all.
+        if (lr_miss_i) begin
           miss_addr_n = miss_addr_i;
           dirty_lru_flopped_n = 1'b0;
-          load_not_store_n = load_miss_i;
+          load_not_store_n = 1'b0; // We force a store miss to upgrade the block to exclusive
           cce_data_received_n = 1'b0;
           set_tag_received_n = 1'b0;
 
           cache_miss_o = 1'b1;
           state_n = e_SEND_CACHED_REQ;
         end
-        else if (lr_miss_i) begin
+        else if (load_miss_i | store_miss_i) begin
           miss_addr_n = miss_addr_i;
           dirty_lru_flopped_n = 1'b0;
-          load_not_store_n = 1'b0; // We force a store miss to upgrade the block to exclusive
+          load_not_store_n = load_miss_i;
           cce_data_received_n = 1'b0;
           set_tag_received_n = 1'b0;
 


### PR DESCRIPTION
This change fixes when and how the D$ issues a miss request for a load-reserved instruction.
1. The LR should miss if the block is cached read-only or if the block is not cached at all.
2. The LR must take priority over the load_miss_i signal in the LCE Request module so the request is properly issued as a store miss, which will result in the D$ receiving the block with read/write permissions.