### PR TITLE
Adding locking logic to d$ to guarantee (eventual) atomicity for LR/S…

### DIFF
--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -461,7 +461,7 @@ module bp_be_dcache
   logic [dword_width_p-1:0] uncached_load_data_r;
 
   // load reserved / store conditional
-  logic lr_miss_tv;
+  logic lr_hit_tv, lr_miss_tv;
   logic sc_success;
   logic sc_fail;
   logic [ptag_width_lp-1:0]  load_reserved_tag_r;
@@ -469,6 +469,7 @@ module bp_be_dcache
   logic load_reserved_v_r;
 
   // Upgrade if a load reserved and we don't have the line in exclusive state
+  assign lr_hit_tv = v_tv_r & lr_op_tv_r & load_hit;
   assign lr_miss_tv = v_tv_r & lr_op_tv_r & load_hit & ~store_hit;
   // Succeed if the address matches and we have a store hit
   assign sc_success  = v_tv_r & sc_op_tv_r & store_hit & load_reserved_v_r 
@@ -639,7 +640,7 @@ module bp_be_dcache
   logic lce_stat_mem_pkt_v;
   logic lce_stat_mem_pkt_yumi;
  
-  logic lce_cmd_ready_lo, lce_cmd_lock_lo;
+  logic lce_cmd_v_li, lce_cmd_lock_lo;
   bp_be_dcache_lce
     #(.bp_params_p(bp_params_p))
     lce
@@ -686,8 +687,8 @@ module bp_be_dcache
       ,.lce_resp_ready_i(lce_resp_ready_i)
 
       ,.lce_cmd_i(lce_cmd_i)
-      ,.lce_cmd_v_i(lce_cmd_v_i)
-      ,.lce_cmd_ready_o(lce_cmd_ready_lo)
+      ,.lce_cmd_v_i(lce_cmd_v_li)
+      ,.lce_cmd_ready_o(lce_cmd_ready_o)
 
       ,.lce_cmd_o(lce_cmd_o)
       ,.lce_cmd_v_o(lce_cmd_v_o)
@@ -1070,7 +1071,7 @@ module bp_be_dcache
   //      sequences meet certain conditions.  By ignoring incoming invalidations for a short period
   //      after each LR, we minimize the chance of SC failure at the cost of less coherence
   //      responsiveness
-  // TODO: Extra into bsg_edge_detector
+  // TODO: Extract into bsg_edge_detector
   logic cache_miss_r;
   always_ff @(posedge clk_i)
     cache_miss_r <= cache_miss_o;
@@ -1078,7 +1079,7 @@ module bp_be_dcache
 
   logic [`BSG_SAFE_CLOG2(lock_max_limit_p+1)-1:0] lock_cnt_r;
   wire lock_clr = v_o || (lock_cnt_r == lock_max_limit_p);
-  wire lock_inc = ~lock_clr & (cache_miss_resolved || lr_op_tv_r || (lock_cnt_r > 0));
+  wire lock_inc = ~lock_clr & (cache_miss_resolved || lr_hit_tv || (lock_cnt_r > 0));
   bsg_counter_clear_up
    #(.max_val_p(lock_max_limit_p)
      ,.init_val_p(0)
@@ -1092,8 +1093,10 @@ module bp_be_dcache
      ,.up_i(lock_inc)
      ,.count_o(lock_cnt_r)
      );
+  // We could actually be more clever here.  We only need to block invalidations to this
+  //   specific line.  However, being extra safe is easier to implement for now.
   assign lce_cmd_lock_lo = (lock_cnt_r != '0);
-  assign lce_cmd_ready_o = lce_cmd_ready_lo & ~lce_cmd_lock_lo;
+  assign lce_cmd_v_li = lce_cmd_v_i & ~lce_cmd_lock_lo;
 
   // synopsys translate_off
   if (debug_p) begin: axe

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -138,7 +138,7 @@ module bp_be_dcache
     // CCE-LCE interface
     , input [lce_cmd_width_lp-1:0] lce_cmd_i
     , input lce_cmd_v_i
-    , output logic lce_cmd_ready_o
+    , output logic lce_cmd_yumi_o
 
     // LCE-LCE interface
     , output logic [lce_cmd_width_lp-1:0] lce_cmd_o
@@ -469,8 +469,8 @@ module bp_be_dcache
   logic load_reserved_v_r;
 
   // Upgrade if a load reserved and we don't have the line in exclusive state
-  assign lr_hit_tv = v_tv_r & lr_op_tv_r & load_hit;
-  assign lr_miss_tv = v_tv_r & lr_op_tv_r & load_hit & ~store_hit;
+  assign lr_hit_tv = v_tv_r & lr_op_tv_r & store_hit;
+  assign lr_miss_tv = v_tv_r & lr_op_tv_r & ~store_hit;
   // Succeed if the address matches and we have a store hit
   assign sc_success  = v_tv_r & sc_op_tv_r & store_hit & load_reserved_v_r 
                        & (load_reserved_tag_r == addr_tag_tv)
@@ -688,7 +688,7 @@ module bp_be_dcache
 
       ,.lce_cmd_i(lce_cmd_i)
       ,.lce_cmd_v_i(lce_cmd_v_li)
-      ,.lce_cmd_ready_o(lce_cmd_ready_o)
+      ,.lce_cmd_yumi_o(lce_cmd_yumi_o)
 
       ,.lce_cmd_o(lce_cmd_o)
       ,.lce_cmd_v_o(lce_cmd_v_o)

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce.v
@@ -121,7 +121,7 @@ module bp_be_dcache_lce
     // CCE-LCE interface
     , input [lce_cmd_width_lp-1:0] lce_cmd_i
     , input lce_cmd_v_i
-    , output logic lce_cmd_ready_o
+    , output logic lce_cmd_yumi_o
 
     // LCE-LCE interface
     , output logic [lce_cmd_width_lp-1:0] lce_cmd_o
@@ -275,7 +275,7 @@ module bp_be_dcache_lce
 
       ,.lce_cmd_i(lce_cmd_in)
       ,.lce_cmd_v_i(lce_cmd_v_i)
-      ,.lce_cmd_ready_o(lce_cmd_ready_o)
+      ,.lce_cmd_yumi_o(lce_cmd_yumi_o)
 
       ,.lce_resp_o(lce_cmd_to_lce_resp_lo)
       ,.lce_resp_v_o(lce_cmd_to_lce_resp_v_lo)
@@ -330,6 +330,7 @@ module bp_be_dcache_lce
   bsg_counter_clear_up
    #(.max_val_p(timeout_max_limit_p)
      ,.init_val_p(0)
+     ,.disable_overflow_warning_p(1)
      )
    timeout_counter
     (.clk_i(clk_i)

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_cmd.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_cmd.v
@@ -64,7 +64,7 @@ module bp_be_dcache_lce_cmd
     // CCE_LCE_cmd
     , input [lce_cmd_width_lp-1:0] lce_cmd_i
     , input lce_cmd_v_i
-    , output logic lce_cmd_ready_o
+    , output logic lce_cmd_yumi_o
 
     // LCE_CCE_resp
     , output logic [lce_cce_resp_width_lp-1:0] lce_resp_o
@@ -101,10 +101,10 @@ module bp_be_dcache_lce_cmd
   `declare_bp_be_dcache_lce_stat_mem_pkt_s(sets_p, ways_p);
 
   bp_lce_cmd_s lce_cmd_li;
-  logic lce_cmd_v_li, lce_cmd_yumi_lo;
   bp_lce_cce_resp_s lce_resp;
   bp_lce_cmd_s lce_cmd_out;
 
+  assign lce_cmd_li = lce_cmd_i;
   assign lce_resp_o = lce_resp;
   assign lce_cmd_o = lce_cmd_out;
 
@@ -186,7 +186,7 @@ module bp_be_dcache_lce_cmd
     uncached_data_received_o = 1'b0;
     cce_data_received_o = 1'b0;
 
-    lce_cmd_yumi_lo = 1'b0;
+    lce_cmd_yumi_o = 1'b0;
 
     lce_resp = '0;
     lce_resp_v_o = 1'b0;
@@ -214,20 +214,18 @@ module bp_be_dcache_lce_cmd
                     ? e_lce_cmd_state_sync
                     : e_lce_cmd_state_uncached;
 
-        if (lce_cmd_v_li) begin
-          unique case (lce_cmd_li.msg_type)
-            //  <uncached store done>
-            //  Uncached store done from CCE - decrement flow counter
-            e_lce_cmd_uc_st_done: begin
-              lce_cmd_yumi_lo = lce_cmd_v_li;
-              uncached_store_done_received_o = lce_cmd_v_li;
-            end
+        unique case (lce_cmd_li.msg_type)
+          //  <uncached store done>
+          //  Uncached store done from CCE - decrement flow counter
+          e_lce_cmd_uc_st_done: begin
+            lce_cmd_yumi_o = lce_cmd_v_i;
+            uncached_store_done_received_o = lce_cmd_v_i;
+          end
 
-            // for other message types in this state, use default as defined at top.
-            default: begin
-            end
-          endcase
-        end
+          // for other message types in this state, use default as defined at top.
+          default: begin
+          end
+        endcase
 
       end
 
@@ -237,174 +235,170 @@ module bp_be_dcache_lce_cmd
       // When LCE receives SYNC message, it responds with SYNC-ACK. When LCE received SYNC messages from
       // every CCE in the system, it moves onto READY state.
       e_lce_cmd_state_sync: begin
-        if (lce_cmd_v_li) begin
-          unique case (lce_cmd_li.msg_type)
+        unique case (lce_cmd_li.msg_type)
 
-            e_lce_cmd_sync: begin
-              lce_resp.dst_id = lce_cmd_li.msg.cmd.src_id;
-              lce_resp.src_id = lce_id_i;
-              lce_resp.msg_type = e_lce_cce_sync_ack;
-              lce_resp_v_o = lce_cmd_v_li;
-              lce_cmd_yumi_lo = lce_resp_yumi_i;
-              sync_ack_count_n = lce_resp_yumi_i
-                ? sync_ack_count_r + 1
-                : sync_ack_count_r;
-              state_n = ((sync_ack_count_r == cce_id_width_lp'(num_cce_p-1)) & lce_resp_yumi_i)
-                ? e_lce_cmd_state_ready
-                : e_lce_cmd_state_sync;
-            end
+          e_lce_cmd_sync: begin
+            lce_resp.dst_id = lce_cmd_li.msg.cmd.src_id;
+            lce_resp.src_id = lce_id_i;
+            lce_resp.msg_type = e_lce_cce_sync_ack;
+            lce_resp_v_o = lce_cmd_v_i;
+            lce_cmd_yumi_o = lce_resp_yumi_i;
+            sync_ack_count_n = lce_resp_yumi_i
+              ? sync_ack_count_r + 1
+              : sync_ack_count_r;
+            state_n = ((sync_ack_count_r == cce_id_width_lp'(num_cce_p-1)) & lce_resp_yumi_i)
+              ? e_lce_cmd_state_ready
+              : e_lce_cmd_state_sync;
+          end
 
-            e_lce_cmd_set_clear: begin
-              tag_mem_pkt.index = lce_cmd_addr_index;
-              tag_mem_pkt.opcode = e_dcache_lce_tag_mem_set_clear;
-              tag_mem_pkt_v_o = lce_cmd_v_li;
+          e_lce_cmd_set_clear: begin
+            tag_mem_pkt.index = lce_cmd_addr_index;
+            tag_mem_pkt.opcode = e_dcache_lce_tag_mem_set_clear;
+            tag_mem_pkt_v_o = lce_cmd_v_i;
 
-              stat_mem_pkt.index = lce_cmd_addr_index;
-              stat_mem_pkt.opcode = e_dcache_lce_stat_mem_set_clear;
-              stat_mem_pkt_v_o = lce_cmd_v_li;
+            stat_mem_pkt.index = lce_cmd_addr_index;
+            stat_mem_pkt.opcode = e_dcache_lce_stat_mem_set_clear;
+            stat_mem_pkt_v_o = lce_cmd_v_i;
 
-              lce_cmd_yumi_lo = tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i;
-            end
+            lce_cmd_yumi_o = tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i;
+          end
   
-            // for other message types in this state, use default as defined at top.
-            default: begin
-	       
-            end
-          endcase 
-        end
+          // for other message types in this state, use default as defined at top.
+          default: begin
+	     
+          end
+        endcase 
       end
 
       // < READY >
       // LCE is ready to process cce_lce_cmd packets. In general, the packets are dequeued, when LCE
       // has finished with the job related to the packet.
       e_lce_cmd_state_ready: begin
-        if (lce_cmd_v_li) begin
-          unique case (lce_cmd_li.msg_type)
-            // <transfer packet>
-            // LCE first reads the data mem, and moves onto TRANSFER state.
-            e_lce_cmd_transfer: begin
-              data_mem_pkt.index = lce_cmd_addr_index;
-              data_mem_pkt.way_id = lce_cmd_li.way_id;
-              data_mem_pkt.opcode = e_dcache_lce_data_mem_read;
-              data_mem_pkt_v_o = lce_cmd_v_li;
+        unique case (lce_cmd_li.msg_type)
+          // <transfer packet>
+          // LCE first reads the data mem, and moves onto TRANSFER state.
+          e_lce_cmd_transfer: begin
+            data_mem_pkt.index = lce_cmd_addr_index;
+            data_mem_pkt.way_id = lce_cmd_li.way_id;
+            data_mem_pkt.opcode = e_dcache_lce_data_mem_read;
+            data_mem_pkt_v_o = lce_cmd_v_i;
 
-              state_n = data_mem_pkt_yumi_i
-                ? e_lce_cmd_state_tr
-                : e_lce_cmd_state_ready;
-            end
+            state_n = data_mem_pkt_yumi_i
+              ? e_lce_cmd_state_tr
+              : e_lce_cmd_state_ready;
+          end
 
-            //  <writeback packet>
-            //  LCE is asked to writeback a cache line.
-            //  It first reads stat_mem to check if the line is dirty.
-            e_lce_cmd_writeback: begin
-              stat_mem_pkt.index = lce_cmd_addr_index;
-              stat_mem_pkt.way_id = lce_cmd_li.way_id;
-              stat_mem_pkt.opcode = e_dcache_lce_stat_mem_read;
-              stat_mem_pkt_v_o = lce_cmd_v_li;
+          //  <writeback packet>
+          //  LCE is asked to writeback a cache line.
+          //  It first reads stat_mem to check if the line is dirty.
+          e_lce_cmd_writeback: begin
+            stat_mem_pkt.index = lce_cmd_addr_index;
+            stat_mem_pkt.way_id = lce_cmd_li.way_id;
+            stat_mem_pkt.opcode = e_dcache_lce_stat_mem_read;
+            stat_mem_pkt_v_o = lce_cmd_v_i;
 
-              state_n = stat_mem_pkt_yumi_i
-                ? e_lce_cmd_state_wb
-                : e_lce_cmd_state_ready;
-            end
+            state_n = stat_mem_pkt_yumi_i
+              ? e_lce_cmd_state_wb
+              : e_lce_cmd_state_ready;
+          end
 
-            //  <set tag>
-            //  set the tag and coherency state of given index/way.
-            e_lce_cmd_set_tag: begin
-              tag_mem_pkt.index = lce_cmd_addr_index;
-              tag_mem_pkt.way_id = lce_cmd_li.way_id;
-              tag_mem_pkt.state = lce_cmd_li.msg.cmd.state;
-              tag_mem_pkt.tag = lce_cmd_addr_tag;
-              tag_mem_pkt.opcode = e_dcache_lce_tag_mem_set_tag;
-              tag_mem_pkt_v_o = lce_cmd_v_li;
+          //  <set tag>
+          //  set the tag and coherency state of given index/way.
+          e_lce_cmd_set_tag: begin
+            tag_mem_pkt.index = lce_cmd_addr_index;
+            tag_mem_pkt.way_id = lce_cmd_li.way_id;
+            tag_mem_pkt.state = lce_cmd_li.msg.cmd.state;
+            tag_mem_pkt.tag = lce_cmd_addr_tag;
+            tag_mem_pkt.opcode = e_dcache_lce_tag_mem_set_tag;
+            tag_mem_pkt_v_o = lce_cmd_v_i;
 
-              lce_cmd_yumi_lo = tag_mem_pkt_yumi_i;
+            lce_cmd_yumi_o = tag_mem_pkt_yumi_i;
 
-              set_tag_received_o = tag_mem_pkt_yumi_i;
-            end
+            set_tag_received_o = tag_mem_pkt_yumi_i;
+          end
 
-            //  <set tag wakeup>
-            //  set the tag and send wake-up signal to lce_cce_req module.
-            e_lce_cmd_set_tag_wakeup: begin
-              tag_mem_pkt.index = lce_cmd_addr_index;
-              tag_mem_pkt.way_id = lce_cmd_li.way_id;
-              tag_mem_pkt.state = lce_cmd_li.msg.cmd.state;
-              tag_mem_pkt.tag = lce_cmd_addr_tag;
-              tag_mem_pkt.opcode = e_dcache_lce_tag_mem_set_tag;
-              tag_mem_pkt_v_o = lce_cmd_v_li;
+          //  <set tag wakeup>
+          //  set the tag and send wake-up signal to lce_cce_req module.
+          e_lce_cmd_set_tag_wakeup: begin
+            tag_mem_pkt.index = lce_cmd_addr_index;
+            tag_mem_pkt.way_id = lce_cmd_li.way_id;
+            tag_mem_pkt.state = lce_cmd_li.msg.cmd.state;
+            tag_mem_pkt.tag = lce_cmd_addr_tag;
+            tag_mem_pkt.opcode = e_dcache_lce_tag_mem_set_tag;
+            tag_mem_pkt_v_o = lce_cmd_v_i;
 
-              lce_cmd_yumi_lo = tag_mem_pkt_yumi_i;
+            lce_cmd_yumi_o = tag_mem_pkt_yumi_i;
 
-              set_tag_wakeup_received_o = tag_mem_pkt_yumi_i;
-            end
+            set_tag_wakeup_received_o = tag_mem_pkt_yumi_i;
+          end
 
-            //  <invalidate tag>
-            //  invalidate tag. It does not update the LRU. It sends out
-            //  invalidate_ack response.
-            e_lce_cmd_invalidate_tag: begin
-              tag_mem_pkt.index = lce_cmd_addr_index;
-              tag_mem_pkt.way_id = lce_cmd_li.way_id;
-              tag_mem_pkt.opcode = e_dcache_lce_tag_mem_invalidate;
-              tag_mem_pkt_v_o = invalidated_tag_r
-                ? 1'b0
-                : lce_cmd_v_li;
-              invalidated_tag_n = lce_resp_yumi_i
-                ? 1'b0
-                : (invalidated_tag_r
-                  ? 1'b1
-                  : tag_mem_pkt_yumi_i);
+          //  <invalidate tag>
+          //  invalidate tag. It does not update the LRU. It sends out
+          //  invalidate_ack response.
+          e_lce_cmd_invalidate_tag: begin
+            tag_mem_pkt.index = lce_cmd_addr_index;
+            tag_mem_pkt.way_id = lce_cmd_li.way_id;
+            tag_mem_pkt.opcode = e_dcache_lce_tag_mem_invalidate;
+            tag_mem_pkt_v_o = invalidated_tag_r
+              ? 1'b0
+              : lce_cmd_v_i;
+            invalidated_tag_n = lce_resp_yumi_i
+              ? 1'b0
+              : (invalidated_tag_r
+                ? 1'b1
+                : tag_mem_pkt_yumi_i);
 
-              lce_resp.dst_id = lce_cmd_li.msg.cmd.src_id;
-              lce_resp.msg_type = e_lce_cce_inv_ack;
-              lce_resp.src_id = lce_id_i;
-              lce_resp.addr = lce_cmd_li.msg.cmd.addr;
-              lce_resp_v_o = invalidated_tag_r | tag_mem_pkt_yumi_i;
-              lce_cmd_yumi_lo = lce_resp_yumi_i;
-            end
+            lce_resp.dst_id = lce_cmd_li.msg.cmd.src_id;
+            lce_resp.msg_type = e_lce_cce_inv_ack;
+            lce_resp.src_id = lce_id_i;
+            lce_resp.addr = lce_cmd_li.msg.cmd.addr;
+            lce_resp_v_o = invalidated_tag_r | tag_mem_pkt_yumi_i;
+            lce_cmd_yumi_o = lce_resp_yumi_i;
+          end
 
-            //  <uncached store done>
-            //  Uncached store done from CCE - decrement flow counter
-            e_lce_cmd_uc_st_done: begin
-              lce_cmd_yumi_lo = lce_cmd_v_li;
-              uncached_store_done_received_o = lce_cmd_v_li;
-            end
+          //  <uncached store done>
+          //  Uncached store done from CCE - decrement flow counter
+          e_lce_cmd_uc_st_done: begin
+            lce_cmd_yumi_o = lce_cmd_v_i;
+            uncached_store_done_received_o = lce_cmd_v_i;
+          end
 
-            e_lce_cmd_data: begin
-              data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
-              data_mem_pkt.way_id = lce_cmd_li.way_id;
-              data_mem_pkt.data = lce_cmd_li.msg.dt_cmd.data;
-              data_mem_pkt.opcode = e_dcache_lce_data_mem_write;
-              data_mem_pkt_v_o = lce_cmd_v_li;
+          e_lce_cmd_data: begin
+            data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
+            data_mem_pkt.way_id = lce_cmd_li.way_id;
+            data_mem_pkt.data = lce_cmd_li.msg.dt_cmd.data;
+            data_mem_pkt.opcode = e_dcache_lce_data_mem_write;
+            data_mem_pkt_v_o = lce_cmd_v_i;
 
-              tag_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
-              tag_mem_pkt.way_id = lce_cmd_li.way_id;
-              tag_mem_pkt.state = lce_cmd_li.msg.dt_cmd.state;
-              tag_mem_pkt.tag = lce_cmd_li.msg.dt_cmd.addr[block_offset_width_lp+index_width_lp+:tag_width_lp];
-              tag_mem_pkt.opcode = e_dcache_lce_tag_mem_set_tag;
-              tag_mem_pkt_v_o = lce_cmd_v_li;
+            tag_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
+            tag_mem_pkt.way_id = lce_cmd_li.way_id;
+            tag_mem_pkt.state = lce_cmd_li.msg.dt_cmd.state;
+            tag_mem_pkt.tag = lce_cmd_li.msg.dt_cmd.addr[block_offset_width_lp+index_width_lp+:tag_width_lp];
+            tag_mem_pkt.opcode = e_dcache_lce_tag_mem_set_tag;
+            tag_mem_pkt_v_o = lce_cmd_v_i;
 
-              lce_cmd_yumi_lo     = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            lce_cmd_yumi_o      = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
 
-              cce_data_received_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-              set_tag_received_o  = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            cce_data_received_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            set_tag_received_o  = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
 
-            end
+          end
 
-            e_lce_cmd_uc_data: begin
-              data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
-              data_mem_pkt.way_id = lce_cmd_li.way_id;
-              data_mem_pkt.data = lce_cmd_li.msg.dt_cmd.data;
-              data_mem_pkt.opcode = e_dcache_lce_data_mem_uncached;
-              data_mem_pkt_v_o = lce_cmd_v_li;
-              lce_cmd_yumi_lo = data_mem_pkt_yumi_i;
+          e_lce_cmd_uc_data: begin
+            data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
+            data_mem_pkt.way_id = lce_cmd_li.way_id;
+            data_mem_pkt.data = lce_cmd_li.msg.dt_cmd.data;
+            data_mem_pkt.opcode = e_dcache_lce_data_mem_uncached;
+            data_mem_pkt_v_o = lce_cmd_v_i;
+            lce_cmd_yumi_o = data_mem_pkt_yumi_i;
 
-              uncached_data_received_o = data_mem_pkt_yumi_i;
-            end
-            // for other message types in this state, use default as defined at top.
-            default: begin
+            uncached_data_received_o = data_mem_pkt_yumi_i;
+          end
+          // for other message types in this state, use default as defined at top.
+          default: begin
 
-            end
-          endcase
-        end
+          end
+        endcase
       end
 
       // <TRANSFER state>    
@@ -423,9 +417,9 @@ module bp_be_dcache_lce_cmd
         lce_cmd_out.msg.dt_cmd.data = tr_data_buffered_r
           ? data_buf_r
           : data_mem_data_i;
-        lce_cmd_v_o = 1'b1;
+        lce_cmd_v_o = lce_cmd_ready_i;
 
-        lce_cmd_yumi_lo = lce_tr_done;
+        lce_cmd_yumi_o = lce_tr_done;
         state_n = lce_tr_done
           ? e_lce_cmd_state_ready
           : e_lce_cmd_state_tr;
@@ -484,7 +478,7 @@ module bp_be_dcache_lce_cmd
         lce_resp.dst_id = lce_cmd_li.msg.cmd.src_id;
         lce_resp_v_o = wb_data_read_r & (wb_dirty_cleared_r | stat_mem_pkt_yumi_i);
 
-        lce_cmd_yumi_lo = lce_resp_done;
+        lce_cmd_yumi_o = lce_resp_done;
 
         state_n = lce_resp_done
           ? e_lce_cmd_state_ready
@@ -501,7 +495,7 @@ module bp_be_dcache_lce_cmd
         lce_resp.dst_id = lce_cmd_li.msg.cmd.src_id;
         lce_resp_v_o = 1'b1;
 
-        lce_cmd_yumi_lo = lce_resp_done;
+        lce_cmd_yumi_o = lce_resp_done;
 
         state_n = lce_resp_done
           ? e_lce_cmd_state_ready
@@ -540,24 +534,5 @@ module bp_be_dcache_lce_cmd
       invalidated_tag_r <= invalidated_tag_n;
     end
   end
-
-  // We need this converter because the LCE expects this interface to be valid-yumi, while
-  // the network links are ready-and-valid. It's possible that we could modify the LCE to 
-  // be helpful and avoid this
-  bsg_two_fifo 
-   #(.width_p(lce_cmd_width_lp))
-   rv_adapter
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.data_i(lce_cmd_i)
-     ,.v_i(lce_cmd_v_i)
-     ,.ready_o(lce_cmd_ready_o)
-
-     ,.data_o(lce_cmd_li)
-     ,.v_o(lce_cmd_v_li)
-     ,.yumi_i(lce_cmd_yumi_lo)
-     );
-
 
 endmodule

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v
@@ -88,11 +88,11 @@ module bp_be_dcache_lce_req
   bp_lce_cce_req_s lce_req;
   bp_lce_cce_resp_s lce_resp;
 
+  assign lce_req_o = lce_req;
   assign lce_resp_o = lce_resp;
 
   // For uncached store buffering
   //
-  logic lce_req_v_lo, lce_req_ready_li;
 
   // states
   //
@@ -123,6 +123,7 @@ module bp_be_dcache_lce_req
 
   always_comb begin
     cache_miss_o = 1'b0;
+    lce_req_uncached_store_o = 1'b0;
 
     state_n = state_r;
     load_not_store_n = load_not_store_r;
@@ -135,7 +136,7 @@ module bp_be_dcache_lce_req
     cce_data_received_n = cce_data_received_r;
     set_tag_received_n = set_tag_received_r;
 
-    lce_req_v_lo = 1'b0;
+    lce_req_v_o = 1'b0;
 
     lce_req.dst_id = (num_cce_p > 1) ? miss_addr_r[block_offset_width_lp+:cce_id_width_lp] : 1'b0;
     lce_req.src_id = lce_id_i;
@@ -186,7 +187,7 @@ module bp_be_dcache_lce_req
           state_n = e_SEND_UNCACHED_LOAD_REQ;
         end
         else if (uncached_store_req_i) begin
-          lce_req_v_lo = ~credits_full_i & lce_req_ready_li;
+          lce_req_v_o = ~credits_full_i & lce_req_ready_i;
 
           lce_req.msg.uc_req.data = store_data_i;
           lce_req.msg.uc_req.uc_size = bp_lce_cce_uc_req_size_e'(size_op_i);
@@ -195,7 +196,8 @@ module bp_be_dcache_lce_req
           lce_req.src_id = lce_id_i;
           lce_req.dst_id = (num_cce_p > 1) ? miss_addr_i[block_offset_width_lp+:cce_id_width_lp] : 1'b0;
 
-          cache_miss_o = ~lce_req_ready_li | credits_full_i;
+          cache_miss_o = ~lce_req_ready_i | credits_full_i;
+          lce_req_uncached_store_o = ~cache_miss_o;
           state_n = e_READY;
         end
         else begin
@@ -211,7 +213,7 @@ module bp_be_dcache_lce_req
         lru_way_n = dirty_lru_flopped_r ? lru_way_r : lru_way_i;
         dirty_n = dirty_lru_flopped_r ? dirty_r : dirty_i[lru_way_i];
 
-        lce_req_v_lo = 1'b1;
+        lce_req_v_o = 1'b1;
 
         lce_req.msg.req.pad = '0;
         lce_req.msg.req.lru_dirty = dirty_lru_flopped_r
@@ -230,14 +232,14 @@ module bp_be_dcache_lce_req
         lce_req.dst_id = (num_cce_p > 1) ? miss_addr_r[block_offset_width_lp+:cce_id_width_lp] : 1'b0;
 
         cache_miss_o = 1'b1;
-        state_n = lce_req_ready_li
+        state_n = lce_req_ready_i
           ? e_SLEEP
           : e_SEND_CACHED_REQ;
       end
 
       // SEND UNCACHED_LOAD_REQ
       e_SEND_UNCACHED_LOAD_REQ: begin
-        lce_req_v_lo = 1'b1;
+        lce_req_v_o = 1'b1;
 
         lce_req.msg.uc_req.data = '0;
         lce_req.msg.uc_req.uc_size = bp_lce_cce_uc_req_size_e'(size_op_r);
@@ -247,7 +249,7 @@ module bp_be_dcache_lce_req
         lce_req.dst_id = (num_cce_p > 1) ? miss_addr_r[block_offset_width_lp+:cce_id_width_lp] : 1'b0;
 
         cache_miss_o = 1'b1;
-        state_n = lce_req_ready_li
+        state_n = lce_req_ready_i
           ? e_SLEEP
           : e_SEND_UNCACHED_LOAD_REQ;
       end
@@ -296,22 +298,6 @@ module bp_be_dcache_lce_req
       end
     endcase
   end
-
-  // We need this converter because the LCE expects the store data to go out when valid
-  bsg_one_fifo
-   #(.width_p(lce_cce_req_width_lp+1))
-   rv_adapter
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.data_i({uncached_store_req_i, lce_req})
-     ,.v_i(lce_req_v_lo)
-     ,.ready_o(lce_req_ready_li)
-
-     ,.data_o({lce_req_uncached_store_o, lce_req_o})
-     ,.v_o(lce_req_v_o)
-     ,.yumi_i(lce_req_ready_i & lce_req_v_o)
-     );
 
   // sequential
   //

--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -78,7 +78,7 @@ module bp_be_mem_top
 
    , input [lce_cmd_width_lp-1:0]            lce_cmd_i
    , input                                   lce_cmd_v_i
-   , output                                  lce_cmd_ready_o
+   , output                                  lce_cmd_yumi_o
 
    , output [lce_cmd_width_lp-1:0]           lce_cmd_o
    , output                                  lce_cmd_v_o
@@ -356,7 +356,7 @@ bp_be_dcache
     // CCE-LCE interface
     ,.lce_cmd_i(lce_cmd_i)
     ,.lce_cmd_v_i(lce_cmd_v_i)
-    ,.lce_cmd_ready_o(lce_cmd_ready_o)
+    ,.lce_cmd_yumi_o(lce_cmd_yumi_o)
 
     ,.lce_cmd_o(lce_cmd_o)
     ,.lce_cmd_v_o(lce_cmd_v_o)

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -57,7 +57,7 @@ module bp_be_top
 
    , input [lce_cmd_width_lp-1:0]            lce_cmd_i
    , input                                   lce_cmd_v_i
-   , output                                  lce_cmd_ready_o
+   , output                                  lce_cmd_yumi_o
 
    , output [lce_cmd_width_lp-1:0]           lce_cmd_o
    , output                                  lce_cmd_v_o
@@ -228,7 +228,7 @@ bp_be_mem_top
 
     ,.lce_cmd_i(lce_cmd_i)
     ,.lce_cmd_v_i(lce_cmd_v_i)
-    ,.lce_cmd_ready_o(lce_cmd_ready_o)
+    ,.lce_cmd_yumi_o(lce_cmd_yumi_o)
 
     ,.lce_cmd_o(lce_cmd_o)
     ,.lce_cmd_v_o(lce_cmd_v_o)

--- a/bp_fe/src/v/bp_fe_icache.v
+++ b/bp_fe/src/v/bp_fe_icache.v
@@ -58,7 +58,7 @@ module bp_fe_icache
 
     , input [lce_cmd_width_lp-1:0]                     lce_cmd_i
     , input                                            lce_cmd_v_i
-    , output                                           lce_cmd_ready_o
+    , output                                           lce_cmd_yumi_o
 
     , output [lce_cmd_width_lp-1:0]                    lce_cmd_o
     , output                                           lce_cmd_v_o
@@ -330,7 +330,7 @@ module bp_fe_icache
 
      ,.lce_cmd_i(lce_cmd_i)
      ,.lce_cmd_v_i(lce_cmd_v_i)
-     ,.lce_cmd_ready_o(lce_cmd_ready_o)
+     ,.lce_cmd_yumi_o(lce_cmd_yumi_o)
 
      ,.lce_cmd_o(lce_cmd_o)
      ,.lce_cmd_v_o(lce_cmd_v_o)

--- a/bp_fe/src/v/bp_fe_lce.v
+++ b/bp_fe/src/v/bp_fe_lce.v
@@ -39,7 +39,7 @@ module bp_fe_lce
     input                                                        clk_i
     , input                                                      reset_i
 
-    , input [cfg_bus_width_lp-1:0]                              cfg_bus_i
+    , input [cfg_bus_width_lp-1:0]                               cfg_bus_i
 
     , output logic                                               ready_o
     , output logic                                               cache_miss_o
@@ -74,7 +74,7 @@ module bp_fe_lce
 
     , input [lce_cmd_width_lp-1:0] lce_cmd_i
     , input lce_cmd_v_i
-    , output logic lce_cmd_ready_o
+    , output logic lce_cmd_yumi_o
 
     , output logic [lce_cmd_width_lp-1:0] lce_cmd_o
     , output logic lce_cmd_v_o
@@ -186,7 +186,7 @@ module bp_fe_lce
 
     ,.lce_cmd_i(lce_cmd)
     ,.lce_cmd_v_i(lce_cmd_v_i)
-    ,.lce_cmd_ready_o(lce_cmd_ready_o)
+    ,.lce_cmd_yumi_o(lce_cmd_yumi_o)
 
     ,.lce_resp_o(lce_cmd_lce_resp_lo)
     ,.lce_resp_v_o(lce_cmd_lce_resp_v_lo)

--- a/bp_fe/src/v/bp_fe_lce_cmd.v
+++ b/bp_fe/src/v/bp_fe_lce_cmd.v
@@ -63,7 +63,7 @@ module bp_fe_lce_cmd
 
     , input [lce_cmd_width_lp-1:0]                               lce_cmd_i
     , input                                                      lce_cmd_v_i
-    , output logic                                               lce_cmd_ready_o
+    , output logic                                               lce_cmd_yumi_o
     
     , output logic [lce_cmd_width_lp-1:0]                        lce_cmd_o
     , output logic                                               lce_cmd_v_o
@@ -75,10 +75,10 @@ module bp_fe_lce_cmd
   `declare_bp_lce_cce_if(num_cce_p, num_lce_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
 
   bp_lce_cmd_s lce_cmd_li;
-  logic lce_cmd_v_li, lce_cmd_yumi_lo;
   bp_lce_cce_resp_s lce_resp;
   bp_lce_cmd_s lce_cmd_out;
 
+  assign lce_cmd_li    = lce_cmd_i;
   assign lce_resp_o    = lce_resp;
   assign lce_cmd_o     = lce_cmd_out;
  
@@ -97,8 +97,8 @@ module bp_fe_lce_cmd
   bp_fe_icache_lce_tag_mem_pkt_s tag_mem_pkt;
   bp_fe_icache_lce_stat_mem_pkt_s stat_mem_pkt;
 
-  assign data_mem_pkt_o     = data_mem_pkt;
-  assign tag_mem_pkt_o      = tag_mem_pkt;
+  assign data_mem_pkt_o = data_mem_pkt;
+  assign tag_mem_pkt_o  = tag_mem_pkt;
   assign stat_mem_pkt_o = stat_mem_pkt;
 
   // states
@@ -114,7 +114,7 @@ module bp_fe_lce_cmd
   // lce_cmd fsm
   always_comb begin
 
-    lce_cmd_yumi_lo = 1'b0;
+    lce_cmd_yumi_o = 1'b0;
 
     lce_resp = '0;
     lce_resp.src_id = lce_id_i;
@@ -148,15 +148,15 @@ module bp_fe_lce_cmd
           data_mem_pkt.index  = lce_cmd_addr_index;
           data_mem_pkt.way_id = lce_cmd_li.way_id;
           data_mem_pkt.opcode = e_icache_lce_data_mem_read;
-          data_mem_pkt_v_o    = lce_cmd_v_li;
+          data_mem_pkt_v_o    = lce_cmd_v_i;
           state_n             = data_mem_pkt_yumi_i ? e_lce_cmd_transfer_tmp : e_lce_cmd_ready;
 
         end else if (lce_cmd_li.msg_type == e_lce_cmd_writeback) begin
           lce_resp.dst_id   = lce_cmd_li.msg.cmd.src_id;
           lce_resp.msg_type = e_lce_cce_resp_null_wb;
           lce_resp.addr     = lce_cmd_li.msg.cmd.addr;
-          lce_resp_v_o      = lce_cmd_v_li;
-          lce_cmd_yumi_lo   = lce_resp_yumi_i;
+          lce_resp_v_o      = lce_cmd_v_i;
+          lce_cmd_yumi_o    = lce_resp_yumi_i;
 
         end else if (lce_cmd_li.msg_type == e_lce_cmd_set_tag) begin
           tag_mem_pkt.index  = lce_cmd_addr_index;
@@ -164,10 +164,10 @@ module bp_fe_lce_cmd
           tag_mem_pkt.state  = lce_cmd_li.msg.cmd.state;
           tag_mem_pkt.tag    = lce_cmd_addr_tag;
           tag_mem_pkt.opcode = e_tag_mem_set_tag;
-          tag_mem_pkt_v_o    = lce_cmd_v_li;
+          tag_mem_pkt_v_o    = lce_cmd_v_i;
 
-          lce_cmd_yumi_lo     = tag_mem_pkt_yumi_i;
-          set_tag_received_o          = tag_mem_pkt_yumi_i;
+          lce_cmd_yumi_o     = tag_mem_pkt_yumi_i;
+          set_tag_received_o = tag_mem_pkt_yumi_i;
 
         end else if (lce_cmd_li.msg_type == e_lce_cmd_set_tag_wakeup) begin
           tag_mem_pkt.index  = lce_cmd_addr_index;
@@ -175,10 +175,10 @@ module bp_fe_lce_cmd
           tag_mem_pkt.state  = lce_cmd_li.msg.cmd.state;
           tag_mem_pkt.tag    = lce_cmd_addr_tag;
           tag_mem_pkt.opcode = e_tag_mem_set_tag;
-          tag_mem_pkt_v_o    = lce_cmd_v_li;
+          tag_mem_pkt_v_o    = lce_cmd_v_i;
 
-          lce_cmd_yumi_lo     = tag_mem_pkt_yumi_i;
-          set_tag_wakeup_received_o   = tag_mem_pkt_yumi_i;
+          lce_cmd_yumi_o     = tag_mem_pkt_yumi_i;
+          set_tag_wakeup_received_o = tag_mem_pkt_yumi_i;
 
         end else if (lce_cmd_li.msg_type == e_lce_cmd_invalidate_tag) begin
           tag_mem_pkt.index = lce_cmd_addr_index;
@@ -187,7 +187,7 @@ module bp_fe_lce_cmd
           tag_mem_pkt.opcode = e_tag_mem_invalidate;
           tag_mem_pkt_v_o = flag_invalidate_r
             ? 1'b0
-            : lce_cmd_v_li;
+            : lce_cmd_v_i;
           flag_invalidate_n = lce_resp_yumi_i
             ? 1'b0
             : (flag_invalidate_r
@@ -198,23 +198,23 @@ module bp_fe_lce_cmd
           lce_resp.msg_type = e_lce_cce_inv_ack;
           lce_resp.addr = lce_cmd_li.msg.cmd.addr;
           lce_resp_v_o = (flag_invalidate_r | tag_mem_pkt_yumi_i);
-          lce_cmd_yumi_lo = lce_resp_yumi_i;
+          lce_cmd_yumi_o = lce_resp_yumi_i;
 
         end else if (lce_cmd_li.msg_type == e_lce_cmd_data) begin
           data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
           data_mem_pkt.way_id = lce_cmd_li.way_id;
           data_mem_pkt.data = lce_cmd_li.msg.dt_cmd.data;
           data_mem_pkt.opcode = e_icache_lce_data_mem_write;
-          data_mem_pkt_v_o = lce_cmd_v_li;
+          data_mem_pkt_v_o = lce_cmd_v_i;
 
           tag_mem_pkt.index  = miss_addr_i[block_offset_width_lp+:index_width_lp];
           tag_mem_pkt.way_id = lce_cmd_li.way_id;
           tag_mem_pkt.state  = lce_cmd_li.msg.dt_cmd.state;
           tag_mem_pkt.tag    = lce_cmd_li.msg.dt_cmd.addr[block_offset_width_lp+index_width_lp+:tag_width_lp];
           tag_mem_pkt.opcode = e_tag_mem_set_tag;
-          tag_mem_pkt_v_o    = lce_cmd_v_li;
+          tag_mem_pkt_v_o    = lce_cmd_v_i;
 
-          lce_cmd_yumi_lo     = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+          lce_cmd_yumi_o     = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
 
           cce_data_received_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
           set_tag_received_o  = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
@@ -224,8 +224,8 @@ module bp_fe_lce_cmd
               data_mem_pkt.way_id = lce_cmd_li.way_id;
               data_mem_pkt.data = lce_cmd_li.msg.dt_cmd.data;
               data_mem_pkt.opcode = e_icache_lce_data_mem_uncached;
-              data_mem_pkt_v_o = lce_cmd_v_li;
-              lce_cmd_yumi_lo = data_mem_pkt_yumi_i;
+              data_mem_pkt_v_o = lce_cmd_v_i;
+              lce_cmd_yumi_o = data_mem_pkt_yumi_i;
 
               uncached_data_received_o = data_mem_pkt_yumi_i;
             end
@@ -240,9 +240,9 @@ module bp_fe_lce_cmd
         lce_cmd_out.way_id   = lce_cmd_li.msg.cmd.target_way_id;
         lce_cmd_out.msg_type = e_lce_cmd_data;
         lce_cmd_out.dst_id   = lce_cmd_li.msg.cmd.target;
-        lce_cmd_yumi_lo      = lce_cmd_ready_i;
-        lce_cmd_v_o          = 1'b1;
-        state_n              = lce_cmd_ready_i ? e_lce_cmd_ready : e_lce_cmd_transfer_tmp;
+        lce_cmd_v_o          = lce_cmd_ready_i;
+        lce_cmd_yumi_o       = lce_cmd_v_o;
+        state_n              = lce_cmd_v_o ? e_lce_cmd_ready : e_lce_cmd_transfer_tmp;
       end
 
       e_lce_cmd_reset: begin
@@ -251,17 +251,17 @@ module bp_fe_lce_cmd
           tag_mem_pkt.state        = e_COH_I;
           tag_mem_pkt.tag          = '0;
           tag_mem_pkt.opcode       = e_tag_mem_set_clear;
-          tag_mem_pkt_v_o          = lce_cmd_v_li;
+          tag_mem_pkt_v_o          = lce_cmd_v_i;
           stat_mem_pkt.index       = lce_cmd_addr_index;
           stat_mem_pkt.opcode      = e_stat_mem_set_clear;
-          stat_mem_pkt_v_o         = lce_cmd_v_li;
-          lce_cmd_yumi_lo          = tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i;
+          stat_mem_pkt_v_o         = lce_cmd_v_i;
+          lce_cmd_yumi_o           = tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i;
 
         end else if (lce_cmd_li.msg_type == e_lce_cmd_sync) begin
           lce_resp.dst_id = lce_cmd_li.msg.cmd.src_id;
           lce_resp.msg_type = e_lce_cce_sync_ack;
-          lce_resp_v_o = lce_cmd_v_li;
-          lce_cmd_yumi_lo = lce_resp_yumi_i;
+          lce_resp_v_o = lce_cmd_v_i;
+          lce_cmd_yumi_o = lce_resp_yumi_i;
           syn_ack_cnt_n = lce_resp_yumi_i
             ? syn_ack_cnt_r + 1
             : syn_ack_cnt_r;
@@ -291,23 +291,5 @@ module bp_fe_lce_cmd
       flag_invalidate_r    <= flag_invalidate_n;
     end
   end
-
-  // We need this converter because the LCE expects this interface to be valid-yumi, while
-  // the network links are ready-and-valid. It's possible that we could modify the LCE to 
-  // be helpful and avoid this
-  bsg_two_fifo 
-   #(.width_p(lce_cmd_width_lp))
-   rv_adapter
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.data_i(lce_cmd_i)
-     ,.v_i(lce_cmd_v_i)
-     ,.ready_o(lce_cmd_ready_o)
-
-     ,.data_o(lce_cmd_li)
-     ,.v_o(lce_cmd_v_li)
-     ,.yumi_i(lce_cmd_yumi_lo)
-     );
 
 endmodule

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -34,7 +34,7 @@ module bp_fe_mem
 
    , input [lce_cmd_width_lp-1:0]                     lce_cmd_i
    , input                                            lce_cmd_v_i
-   , output                                           lce_cmd_ready_o
+   , output                                           lce_cmd_yumi_o
 
    , output [lce_cmd_width_lp-1:0]                    lce_cmd_o
    , output                                           lce_cmd_v_o
@@ -113,7 +113,7 @@ bp_fe_icache
          
    ,.lce_cmd_i(lce_cmd_i)
    ,.lce_cmd_v_i(lce_cmd_v_i)
-   ,.lce_cmd_ready_o(lce_cmd_ready_o)
+   ,.lce_cmd_yumi_o(lce_cmd_yumi_o)
          
    ,.lce_cmd_o(lce_cmd_o)
    ,.lce_cmd_v_o(lce_cmd_v_o)

--- a/bp_fe/src/v/bp_fe_top.v
+++ b/bp_fe/src/v/bp_fe_top.v
@@ -37,7 +37,7 @@ module bp_fe_top
 
    , input [lce_cmd_width_lp-1:0]                     lce_cmd_i
    , input                                            lce_cmd_v_i
-   , output                                           lce_cmd_ready_o
+   , output                                           lce_cmd_yumi_o
 
    , output [lce_cmd_width_lp-1:0]                    lce_cmd_o
    , output                                           lce_cmd_v_o
@@ -107,7 +107,7 @@ bp_fe_mem
          
    ,.lce_cmd_i(lce_cmd_i)
    ,.lce_cmd_v_i(lce_cmd_v_i)
-   ,.lce_cmd_ready_o(lce_cmd_ready_o)
+   ,.lce_cmd_yumi_o(lce_cmd_yumi_o)
          
    ,.lce_cmd_o(lce_cmd_o)
    ,.lce_cmd_v_o(lce_cmd_v_o)

--- a/bp_top/src/v/bp_core.v
+++ b/bp_top/src/v/bp_core.v
@@ -40,7 +40,7 @@ module bp_core
     // CCE-LCE interface
     , input [1:0][lce_cmd_width_lp-1:0]            lce_cmd_i
     , input [1:0]                                  lce_cmd_v_i
-    , output [1:0]                                 lce_cmd_ready_o
+    , output [1:0]                                 lce_cmd_yumi_o
 
     , output [1:0][lce_cmd_width_lp-1:0]           lce_cmd_o
     , output [1:0]                                 lce_cmd_v_o
@@ -94,7 +94,7 @@ module bp_core
 
      ,.lce_cmd_i(lce_cmd_i[0])
      ,.lce_cmd_v_i(lce_cmd_v_i[0])
-     ,.lce_cmd_ready_o(lce_cmd_ready_o[0])
+     ,.lce_cmd_yumi_o(lce_cmd_yumi_o[0])
 
      ,.lce_cmd_o(lce_cmd_o[0])
      ,.lce_cmd_v_o(lce_cmd_v_o[0])
@@ -182,7 +182,7 @@ module bp_core
 
      ,.lce_cmd_i(lce_cmd_i[1])
      ,.lce_cmd_v_i(lce_cmd_v_i[1])
-     ,.lce_cmd_ready_o(lce_cmd_ready_o[1])
+     ,.lce_cmd_yumi_o(lce_cmd_yumi_o[1])
 
      ,.lce_cmd_o(lce_cmd_o[1])
      ,.lce_cmd_v_o(lce_cmd_v_o[1])

--- a/bp_top/src/v/bp_tile.v
+++ b/bp_top/src/v/bp_tile.v
@@ -27,7 +27,7 @@ module bp_tile
   (input                                                      clk_i
    , input                                                    reset_i
 
-    , output [cfg_bus_width_lp-1:0]                          cfg_bus_o
+   , output [cfg_bus_width_lp-1:0]                           cfg_bus_o
 
    // Memory side connection
    , input [mem_noc_cord_width_p-1:0]                         my_cord_i
@@ -83,7 +83,7 @@ logic             [1:0] lce_req_v_lo, lce_req_ready_li;
 bp_lce_cce_resp_s [1:0] lce_resp_lo;
 logic             [1:0] lce_resp_v_lo, lce_resp_ready_li;
 bp_lce_cmd_s      [1:0] lce_cmd_li;
-logic             [1:0] lce_cmd_v_li, lce_cmd_ready_lo;
+logic             [1:0] lce_cmd_v_li, lce_cmd_yumi_lo;
 bp_lce_cmd_s      [1:0] lce_cmd_lo;
 logic             [1:0] lce_cmd_v_lo, lce_cmd_ready_li;
 
@@ -163,7 +163,7 @@ bp_core
 
    ,.lce_cmd_i(lce_cmd_li)
    ,.lce_cmd_v_i(lce_cmd_v_li)
-   ,.lce_cmd_ready_o(lce_cmd_ready_lo)
+   ,.lce_cmd_yumi_o(lce_cmd_yumi_lo)
 
    ,.lce_cmd_o(lce_cmd_lo)
    ,.lce_cmd_v_o(lce_cmd_v_lo)
@@ -286,7 +286,7 @@ for (genvar i = 0; i < 2; i++)
 
        ,.packet_o(lce_cmd_packet_li[i])
        ,.v_o(lce_cmd_v_li[i])
-       ,.yumi_i(lce_cmd_ready_lo[i] & lce_cmd_v_li[i])
+       ,.yumi_i(lce_cmd_yumi_lo[i])
        );
     assign lce_cmd_li[i] = lce_cmd_packet_li[i].payload;
 


### PR DESCRIPTION
…C and D$ misses

This should improve performance for multi-core LR/SC without introducing live/deadlock conditions.  Additionally prevents that the unlikely case of cache miss starvation in the BE