### PR TITLE
Adding access fault to invalid domain id accesses

### DIFF
--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -331,9 +331,6 @@ module bp_be_dcache
         );
   end
 
-  assign store_op_tl_o = store_op_tl_r;
-  assign load_op_tl_o  = load_op_tl_r;
-
   // TV stage
   //
   logic v_tv_r;
@@ -358,6 +355,9 @@ module bp_be_dcache
   logic [word_offset_width_lp-1:0] addr_word_offset_tv;
 
   assign tv_we = v_tl_r & ~poison_i & ~tlb_miss_i;
+
+  assign store_op_tl_o = tv_we & store_op_tl_r;
+  assign load_op_tl_o  = tv_we & load_op_tl_r;
 
   always_ff @ (posedge clk_i) begin
     if (reset_i) begin

--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -453,8 +453,11 @@ end
 
 // Fault if in uncached mode but access is not for an uncached address
 wire is_uncached_mode = (cfg_bus.dcache_mode == e_lce_mode_uncached);
-assign load_access_fault_v  = is_uncached_mode & (load_op_tl_lo & ~dcache_uncached);
-assign store_access_fault_v = is_uncached_mode & (store_op_tl_lo & ~dcache_uncached);
+wire mode_fault_v = (is_uncached_mode & ~dcache_uncached);
+  // TODO: Enable other domains by setting enabled dids with cfg_bus
+wire did_fault_v = (dcache_ptag[ptag_width_p-1-:io_noc_did_width_p] != '0);
+assign load_access_fault_v  = load_op_tl_lo & (mode_fault_v | did_fault_v);
+assign store_access_fault_v = store_op_tl_lo & (mode_fault_v | did_fault_v);
 
 // D-TLB connections
 assign dtlb_r_v     = dcache_cmd_v;

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -169,8 +169,13 @@ wire instr_priv_access_fault = ((mem_priv_i == `PRIV_MODE_S) & itlb_r_entry.u)
                                | ((mem_priv_i == `PRIV_MODE_U) & ~itlb_r_entry.u);
 wire instr_exe_access_fault = ~itlb_r_entry.x;
 
+// Fault if in uncached mode but access is not for an uncached address
 wire is_uncached_mode = (cfg_bus_cast_i.icache_mode == e_lce_mode_uncached);
-assign instr_access_fault_v = is_uncached_mode & ~uncached_li;
+wire mode_fault_v = (is_uncached_mode & ~uncached_li);
+// TODO: Enable other domains by setting enabled dids with cfg_bus
+wire did_fault_v = (ptag_li[ptag_width_p-1-:io_noc_did_width_p] != '0);
+
+assign instr_access_fault_v = mode_fault_v | did_fault_v;
 assign instr_access_err_v  = fetch_v_r & itlb_r_v_lo & mem_translation_en_i & (instr_priv_access_fault | instr_exe_access_fault);
 
 wire unused = &{mem_resp_ready_i};


### PR DESCRIPTION
We should prohibit memory accesses to chained chips which may not exist.  Speculative or malicious accesses to these addresses will hang the processor.

Future work is to enable foreign domains via the config bus