### PR TITLE
Dispatch packets should be poisoned instead of flushing to be dequeued  from FE queue

### DIFF
--- a/bp_be/src/include/bp_be_internal_if_defines.vh
+++ b/bp_be/src/include/bp_be_internal_if_defines.vh
@@ -112,7 +112,6 @@
   {                                                                                                \
     logic                        v;                                                                \
     logic                        queue_v;                                                          \
-    logic                        bubble_v;                                                         \
     logic                        instret;                                                          \
     logic                        cache_miss;                                                       \
     logic                        tlb_miss;                                                         \
@@ -183,7 +182,7 @@
    )                                                                                               
 
 `define bp_be_commit_pkt_width(vaddr_width_mp) \
-  (6                                                                                               \
+  (5                                                                                               \
    + 2 * vaddr_width_mp                                                                            \
    + instr_width_p                                                                                 \
    )

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -207,7 +207,8 @@ bp_be_dispatch_pkt_s reservation_n, reservation_r;
 always_comb
   begin
     reservation_n        = dispatch_pkt_i;
-    reservation_n.decode = (~flush_i & dispatch_pkt.v) ? dispatch_pkt.decode : '0;
+    reservation_n.decode = dispatch_pkt.v ? dispatch_pkt.decode : '0;
+    reservation_n.poison = (~flush_i & dispatch_pkt.v) ? dispatch_pkt.poison : 1'b1;
     reservation_n.rs1    = bypass_rs1;
     reservation_n.rs2    = bypass_rs2;
   end
@@ -433,7 +434,7 @@ always_comb
         exc_stage_n[2].roll_v          = exc_stage_r[1].roll_v   | pipe_mem_miss_v_lo;
         exc_stage_n[3].roll_v          = exc_stage_r[2].roll_v   | pipe_mem_miss_v_lo;
 
-        exc_stage_n[0].poison_v        = dispatch_pkt.poison     | flush_i;
+        exc_stage_n[0].poison_v        = reservation_n.poison    | flush_i;
         exc_stage_n[1].poison_v        = exc_stage_r[0].poison_v | flush_i;
         exc_stage_n[2].poison_v        = exc_stage_r[1].poison_v | flush_i;
         exc_stage_n[3].poison_v        = exc_stage_r[2].poison_v | pipe_mem_miss_v_lo | pipe_mem_exc_v_lo;

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -203,12 +203,11 @@ bp_be_bypass
    ,.bypass_rs2_o(bypass_irs2)
    );
 
+// Override operands with bypass data
 bp_be_dispatch_pkt_s reservation_n, reservation_r;
 always_comb
   begin
     reservation_n        = dispatch_pkt_i;
-    reservation_n.decode = dispatch_pkt.v ? dispatch_pkt.decode : '0;
-    reservation_n.poison = (~flush_i & dispatch_pkt.v) ? dispatch_pkt.poison : 1'b1;
     reservation_n.rs1    = bypass_rs1;
     reservation_n.rs2    = bypass_rs2;
   end

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -440,10 +440,9 @@ always_comb
   end
 
 assign commit_pkt.v          = calc_stage_r[2].v & ~exc_stage_r[2].poison_v;
-assign commit_pkt.queue_v    = calc_stage_r[2].queue_v & ~exc_stage_r[2].roll_v;
-assign commit_pkt.bubble_v   = ~calc_stage_r[2].queue_v & ~exc_stage_r[2].poison_v;
-assign commit_pkt.instret    = calc_stage_r[2].instr_v & ~exc_stage_n[3].poison_v;
-assign commit_pkt.cache_miss = pipe_mem_miss_v_lo & ~exc_stage_r[2].poison_v;
+assign commit_pkt.queue_v    = calc_stage_r[2].v & calc_stage_r[2].queue_v & ~exc_stage_r[2].roll_v;
+assign commit_pkt.instret    = calc_stage_r[2].v & calc_stage_r[2].instr_v & ~exc_stage_n[3].poison_v;
+assign commit_pkt.cache_miss = calc_stage_r[2].v & pipe_mem_miss_v_lo & ~exc_stage_r[2].poison_v;
 assign commit_pkt.tlb_miss   = 1'b0; // TODO: Add to mem resp
 assign commit_pkt.pc         = calc_stage_r[2].pc;
 assign commit_pkt.npc        = calc_stage_r[1].pc;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.v
@@ -264,7 +264,7 @@ always_comb
 
     // Form dispatch packet
     dispatch_pkt.v      = (issue_pkt_v_r | enter_debug_li | exit_debug_li | accept_irq_i) & dispatch_v_i;
-    dispatch_pkt.poison = (poison_iss_r | npc_mismatch)
+    dispatch_pkt.poison = (poison_iss_r | npc_mismatch | ~dispatch_pkt.v)
                           & ~(accept_irq_i & dispatch_v_i)
                           & ~(enter_debug_li | exit_debug_li);
     dispatch_pkt.pc     = expected_npc_i;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.v
@@ -91,7 +91,7 @@ bsg_dff_reset_en
  issue_pkt_reg
   (.clk_i(clk_i)
    ,.reset_i(reset_i | cache_miss_v_i)
-   ,.en_i(issue_v | dispatch_v_i)
+   ,.en_i(issue_v | (dispatch_v_i & ~accept_irq_i))
    
    ,.data_i({issue_v, issue_pkt})
    ,.data_o({issue_pkt_v_r, issue_pkt_r})
@@ -103,7 +103,7 @@ bsg_dff_reset_en
  issue_status_reg
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
-   ,.en_i(issue_v | dispatch_v_i | poison_iss_i | npc_mismatch)
+   ,.en_i(issue_v | (dispatch_v_i & ~accept_irq_i) | poison_iss_i | npc_mismatch)
 
    ,.data_i(poison_iss_i | npc_mismatch)
    ,.data_o(poison_iss_r)
@@ -190,7 +190,7 @@ always_comb
   end
 
 // Interface handshakes
-assign fe_queue_yumi_o = ~debug_mode_i & ~suppress_iss_i & fe_queue_v_i & (dispatch_v_i | ~issue_pkt_v_r);
+assign fe_queue_yumi_o = ~debug_mode_i & ~suppress_iss_i & fe_queue_v_i & ((dispatch_v_i & ~accept_irq_i) | ~issue_pkt_v_r);
 
 // Queue control signals
 assign fe_queue_clr_o  = ~debug_mode_i & suppress_iss_i;

--- a/bp_be/src/v/bp_be_mem/bp_be_csr.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_csr.v
@@ -33,7 +33,6 @@ module bp_be_csr
     , input [core_id_width_p-1:0]       hartid_i
     , input                             instret_i
 
-    , input                             bubble_v_i
     , input                             exception_v_i
     , input [vaddr_width_p-1:0]         exception_pc_i
     , input [vaddr_width_p-1:0]         exception_npc_i

--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -197,7 +197,6 @@ bsg_dff_chain
 
 bp_be_ecode_dec_s exception_ecode_dec_li;
 
-wire bubble_v_li    = commit_pkt.bubble_v;
 wire exception_v_li = commit_pkt.v | ptw_page_fault_v;
 wire [vaddr_width_p-1:0] exception_pc_li = ptw_page_fault_v ? fault_pc : commit_pkt.pc;
 wire [vaddr_width_p-1:0] exception_npc_li = commit_pkt.npc;
@@ -244,7 +243,6 @@ bp_be_csr
    ,.hartid_i(cfg_bus.core_id)
    ,.instret_i(commit_pkt.instret)
 
-   ,.bubble_v_i(bubble_v_li)
    ,.exception_v_i(exception_v_li)
    ,.exception_pc_i(exception_pc_li)
    ,.exception_npc_i(exception_npc_li)
@@ -485,9 +483,13 @@ assign itlb_fill_vaddr_o = fault_vaddr;
 assign itlb_fill_entry_o = ptw_tlb_w_entry;
 
 // synopsys translate_off
+bp_be_mmu_cmd_s mmu_cmd_r;
+always_ff @(posedge clk_i)
+  mmu_cmd_r <= mmu_cmd;
+
 always_ff @(negedge clk_i)
   begin
-    assert (~(dtlb_r_v_lo & dcache_uncached & mmu_cmd.mem_op inside {e_lrw, e_lrd, e_scw, e_scd}))
+    assert (~(mmu_cmd_v_r & dtlb_r_v_lo & dcache_uncached & (mmu_cmd_r.mem_op inside {e_lrw, e_lrd, e_scw, e_scd})))
       else $warning("LR/SC to uncached memory not supported");
   end
 // synopsys translate_on

--- a/bp_common/src/include/bp_common_pkg.vh
+++ b/bp_common/src/include/bp_common_pkg.vh
@@ -46,7 +46,7 @@ package bp_common_pkg;
   
   localparam mipi_reg_base_addr_gp     = 32'h0030_0000;
   localparam mtimecmp_reg_base_addr_gp = 32'h0030_4000;
-  localparam mtime_reg_addr_gp         = 32'h0030_8000;
+  localparam mtime_reg_addr_gp         = 32'h0030_bff8;
   localparam plic_reg_base_addr_gp     = 32'h0030_b000;
 
   localparam dram_base_addr_gp         = 40'h00_8000_0000;

--- a/bp_top/src/v/bp_clint_slice.v
+++ b/bp_top/src/v/bp_clint_slice.v
@@ -60,7 +60,7 @@ always_comb
     endcase
   end
 
-logic [dword_width_p-1:0] mtime_r, mtimecmp_n, mtimecmp_r;
+logic [dword_width_p-1:0] mtime_r, mtime_val_li, mtimecmp_n, mtimecmp_r;
 logic                     mipi_n, mipi_r;
 logic                     plic_n, plic_r;
 
@@ -76,17 +76,19 @@ bsg_strobe
    ,.init_val_r_i(ds_ratio_li)
    ,.strobe_r_o(mtime_inc_li)
    );
-bsg_counter_clear_up
- #(.max_val_p(2**dword_width_p-1)
-   ,.ptr_width_lp(dword_width_p)
-   ,.init_val_p(0)
+assign mtime_val_li = mem_cmd_li.data[0+:dword_width_p];
+wire mtime_w_v_li = wr_not_rd & mtime_cmd_v;
+bsg_counter_set_en
+ #(.lg_max_val_lp(dword_width_p)
+   ,.reset_val_p(0)
    )
  mtime_counter
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
-   ,.clear_i(1'b0)
 
-   ,.up_i(mtime_inc_li)
+   ,.set_i(mtime_w_v_li)
+   ,.en_i(mtime_inc_li)
+   ,.val_i(mtime_val_li)
    ,.count_o(mtime_r)
    );
 

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -90,6 +90,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_circular_ptr.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_concentrate_static.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_set_down.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_counter_set_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_up_down.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_up_down_variable.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_crossbar_o_by_i.v


### PR DESCRIPTION
When we take a trap all the instructions read from FE queue should be dequeued, but flushing them zeros their `queue_v` field which causes them not to dequeued from the pipe and making problems when rolling back in the future.
Instead, we keep its `decode` field and just poison it in the calculator.