### PR TITLE
A number of unrelated fixes to FE and BE

### DIFF
--- a/bp_be/src/v/bp_be_mem/bp_be_csr.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_csr.v
@@ -272,15 +272,15 @@ bsg_dff_reset
    );
 
 // sstatus mask
-assign sstatus_wmask_li = '{mxr: 1'b1, sum: 1'b1
+assign sstatus_wmask_li = '{fs: 2'b11
+                            ,mxr: 1'b1, sum: 1'b1
                             ,mpp: 2'b00, spp: 2'b11
                             ,mpie: 1'b0, spie: 1'b1
                             ,mie: 1'b0, sie: 1'b1
                             ,default: '0
                             };
-assign sstatus_rmask_li = '{sd: 1'b1, uxl: 2'b11
+assign sstatus_rmask_li = '{sd: 1'b1, uxl: 2'b11, fs: 2'b11
                             ,mxr: 1'b1, sum: 1'b1
-                            ,xs: 2'b11, fs: 2'b11
                             ,mpp: 2'b00, spp: 2'b11
                             ,mpie: 1'b0, spie: 1'b1
                             ,mie: 1'b0, sie: 1'b1

--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -182,7 +182,7 @@ bsg_dff_en
    ,.data_o({fault_vaddr, fault_pc})
    );
 
-wire is_store = mmu_cmd_v_i & mmu_cmd.mem_op inside {e_sb, e_sh, e_sw, e_sd};
+wire is_store = mmu_cmd_v_i & mmu_cmd.mem_op inside {e_sb, e_sh, e_sw, e_sd, e_scw, e_scd};
 
 bsg_dff_chain
  #(.width_p(vaddr_width_p)

--- a/bp_common/src/include/bp_common_csr_defines.vh
+++ b/bp_common/src/include/bp_common_csr_defines.vh
@@ -411,6 +411,8 @@ typedef struct packed
   logic       sum;
   logic       mprv;
 
+  logic [1:0] fs;
+
   logic [1:0] mpp;
   logic       spp;
 
@@ -428,6 +430,7 @@ typedef struct packed
     ,mxr : data_cast_mp.mxr  \
     ,sum : data_cast_mp.sum  \
     ,mprv: data_cast_mp.mprv \
+    ,fs  : data_cast_mp.fs   \
     ,mpp : data_cast_mp.mpp  \
     ,spp : data_cast_mp.spp  \
     ,mpie: data_cast_mp.mpie \
@@ -437,7 +440,8 @@ typedef struct packed
     }
 
 `define decompress_mstatus_s(data_comp_mp) \
-  '{sxl  : 2'b10             \
+  '{sd   : (data_comp_mp.fs == 2'b11) \
+    ,sxl : 2'b10             \
     ,uxl : 2'b10             \
     ,tsr : data_comp_mp.tsr  \
     ,tvm : data_comp_mp.tvm  \
@@ -445,6 +449,7 @@ typedef struct packed
     ,mxr : data_comp_mp.mxr  \
     ,sum : data_comp_mp.sum  \
     ,mprv: data_comp_mp.mprv \
+    ,fs  : data_comp_mp.fs   \
     ,mpp : data_comp_mp.mpp  \
     ,spp : data_comp_mp.spp  \
     ,mpie: data_comp_mp.mpie \

--- a/bp_common/src/v/bp_pma.v
+++ b/bp_common/src/v/bp_pma.v
@@ -12,7 +12,10 @@ module bp_pma
    , output                   uncached_o
    );
 
-  assign uncached_o = ptag_v_i & (ptag_i < (dram_base_addr_gp >> page_offset_width_p));
+  wire is_local_addr = (ptag_i < (dram_base_addr_gp >> page_offset_width_p));
+  wire is_io_addr    = (ptag_i[ptag_width_p-1-:io_noc_did_width_p] != '0);
+
+  assign uncached_o = ptag_v_i & (is_local_addr | is_io_addr);
 
 endmodule
 

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -136,8 +136,10 @@ wire is_uncached_mode = (cfg_bus_cast_i.icache_mode == e_lce_mode_uncached);
 wire mode_fault_v = (is_uncached_mode & ~uncached_li);
 // TODO: Enable other domains by setting enabled dids with cfg_bus
 wire did_fault_v = (ptag_li[ptag_width_p-1-:io_noc_did_width_p] != '0);
+// Don't allow speculative access to local tile memory
+wire local_fault_v = (ptag_li < (dram_base_addr_gp >> page_offset_width_p));
 
-assign instr_access_fault_v = fetch_v_r & (mode_fault_v | did_fault_v);
+assign instr_access_fault_v = fetch_v_r & (mode_fault_v | did_fault_v | local_fault_v);
 assign instr_page_fault_v   = fetch_v_r & itlb_r_v_lo & mem_translation_en_i & (instr_priv_page_fault | instr_exe_page_fault);
 
 assign mem_cmd_yumi_o = itlb_fence_v | itlb_fill_v | fetch_v;


### PR DESCRIPTION
- Fixed not checking access faults on SC instructions
- Enabled FS and SD bits in mstatus CSR which are used by Linux to manage float context switching
- Poison I$ on access and page faults so the I$ doesn't freeze indefinitely 
