### PR TITLE
Check-pointing and Cosimulation with Dromajo

### DIFF
--- a/bp_be/src/include/bp_be_internal_if_defines.vh
+++ b/bp_be/src/include/bp_be_internal_if_defines.vh
@@ -123,6 +123,7 @@
   /* TODO: make opcode */                                                                          \
   typedef struct packed                                                                            \
   {                                                                                                \
+    logic [dword_width_p-1:0]       cause;                                                         \
     logic [vaddr_width_p-1:0]       epc;                                                           \
     logic [vaddr_width_p-1:0]       tvec;                                                          \
     logic [rv64_priv_width_gp-1:0]  priv_n;                                                        \
@@ -188,7 +189,7 @@
    )
  
 `define bp_be_trap_pkt_width(vaddr_width_mp) \
-  (2 * vaddr_width_mp + rv64_priv_width_gp + 4)
+  (2 * vaddr_width_mp + rv64_priv_width_gp + dword_width_p + 4)
 
 `define bp_be_wb_pkt_width(vaddr_width_mp) \
   (1                                                                                               \

--- a/bp_be/src/v/bp_be_mem/bp_be_csr.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_csr.v
@@ -704,6 +704,7 @@ assign trap_pkt_cast_o.epc              = (csr_cmd.csr_op == e_sret)
                                             ? mepc_r
                                             : dpc_r;
 assign trap_pkt_cast_o.tvec             = (priv_mode_n == `PRIV_MODE_S) ? stvec_r : mtvec_r;
+assign trap_pkt_cast_o.cause            = (priv_mode_n == `PRIV_MODE_S) ? scause_li : mcause_li;
 assign trap_pkt_cast_o.priv_n           = priv_mode_n;
 assign trap_pkt_cast_o.translation_en_n = translation_en_n;
 // TODO: Find more solid invariant

--- a/bp_common/.gitignore
+++ b/bp_common/.gitignore
@@ -3,3 +3,6 @@ bsg_defines.v
 *.dump
 *.spike
 *.mem
+*.mainram
+*.bootram
+*.cfg

--- a/bp_common/syn/Makefile.vcs
+++ b/bp_common/syn/Makefile.vcs
@@ -19,6 +19,7 @@ VCS_BUILD_OPTS += -CFLAGS "-I$(BP_EXTERNAL_DIR)/include -std=c++11"
 VCS_BUILD_OPTS += -LDFLAGS "-L$(BP_EXTERNAL_DIR)/lib -ldramsim -Wl,-rpath=$(BP_EXTERNAL_DIR)/lib"
 VCS_BUILD_OPTS += +lint=TFIPC-L
 VCS_BUILD_OPTS += -notice
+VCS_BUILD_OPTS += $(BP_EXTERNAL_DIR)/lib/libdromajo_cosim.a
 
 LINT_OPTIONS = +lint=all,noSVA-UA,noSVA-NSVU,noNS,noVCDE
 
@@ -103,6 +104,9 @@ sim.v: dirs.v
 	-@cp $(MEM_PATH)/$(PROG).mem $(SIM_DIR)/prog.mem
 	-@cp $(MEM_PATH)/$(PROG).riscv $(SIM_DIR)/prog.elf
 	-@cp $(MEM_PATH)/$(PROG).dump $(SIM_DIR)/prog.dump
+	-@cp $(MEM_PATH)/$(PROG).mainram $(SIM_DIR)/prog.mainram
+	-@cp $(MEM_PATH)/$(PROG).bootram $(SIM_DIR)/prog.bootram
+	-@cp $(MEM_PATH)/$(PROG).cfg $(SIM_DIR)/prog.cfg
 	-@cp $(MEM_PATH)/$(PROG).spike $(SIM_DIR)/commit.spike
 	-@cp $(BP_COMMON_DIR)/test/cfg/$(DRAMSIM_CH_CFG) $(SIM_DIR)/dram_ch.ini
 	-@cp $(BP_COMMON_DIR)/test/cfg/$(DRAMSIM_SYS_CFG) $(SIM_DIR)/dram_sys.ini

--- a/bp_common/test/Makefile
+++ b/bp_common/test/Makefile
@@ -11,13 +11,14 @@ MEM_DIR        = $(TEST_DIR)/mem
 
 RISCV_SIM      = spike
 RISCV_OBJDUMP  = riscv64-unknown-elf-objdump -D
-RISCV_OBJCOPY  = riscv64-unknown-elf-objcopy -O verilog
-RISCV_OBJCOPY_BIN = riscv64-unknown-elf-objcopy -O binary
+RISCV_OBJCOPY  = riscv64-unknown-elf-objcopy
 MKLFS = $(TEST_DIR)/bin/bsg_newlib_mklfs
+DROMAJO        = dromajo
 
 PATH := $(BP_EXTERNAL_DIR)/bin:$(PATH)
 
 NC ?= 1
+MEMSIZE ?= 1
 
 export TEST_DIR
 
@@ -186,10 +187,10 @@ riscvdv_spike: $(foreach x, $(BP_RVDV), $(x).spike)
 riscvdv_dump: $(foreach x, $(BP_RVDV), $(x).dump)
 
 %.mem: 
-	$(RISCV_OBJCOPY) $(MEM_DIR)/$*.riscv $(MEM_DIR)/$@
+	$(RISCV_OBJCOPY) -O verilog $(MEM_DIR)/$*.riscv $(MEM_DIR)/$@
 
 %.bin: 
-	$(RISCV_OBJCOPY_BIN) $(MEM_DIR)/$*.riscv $(MEM_DIR)/$@
+	$(RISCV_OBJCOPY) -O binary $(MEM_DIR)/$*.riscv $(MEM_DIR)/$@
 
 %.dump:
 	$(RISCV_OBJDUMP) $(MEM_DIR)/$*.riscv > $(MEM_DIR)/$@
@@ -202,6 +203,26 @@ riscvdv_dump: $(foreach x, $(BP_RVDV), $(x).dump)
 
 %.nbf:
 	$(PYTHON) $(MEM2NBF) $(MEM_DIR)/$*.mem > $(MEM_DIR)/$@
+
+%.dromajo: $(%.config)
+	$(DROMAJO) $(MEM_DIR)/$*.riscv --host --maxinsn=$(MAXINSN) --save=$* --memory_size=$(MEMSIZE)
+	$(RISCV_OBJCOPY) --change-addresses 0x80000000 \
+		 -I binary -O elf64-littleriscv -B riscv $*.mainram $(MEM_DIR)/$@.$(MAXINSN).riscv
+	$(RISCV_OBJCOPY) -O verilog $(MEM_DIR)/$@.$(MAXINSN).riscv $(MEM_DIR)/$@.$(MAXINSN).mem
+	$(RISCV_OBJDUMP) $(MEM_DIR)/$@.$(MAXINSN).riscv > $(MEM_DIR)/$@.$(MAXINSN).dump
+	cp $*.bp_regs $(MEM_DIR)/$@.$(MAXINSN).nbf
+	cp $*.bootram $(MEM_DIR)/$@.$(MAXINSN).bootram
+	cp $*.mainram $(MEM_DIR)/$@.$(MAXINSN).mainram
+	echo -e "\
+	{\n\
+	  \"version\":1,\n\
+	  \"machine\":\"riscv64\",\n\
+	  \"bios\": \"prog.mainram\",\n\
+	  \"load\": \"prog\",\n\
+	  \"memory_base_addr\": 0x80000000,\n\
+	  \"memory_size\": $(MEMSIZE)\n\
+	}" > $(MEM_DIR)/$@.$(MAXINSN).cfg
+	rm $*.*
 
 clean:
 	-$(MAKE) -C $(TEST_DIR)/src/perch clean

--- a/bp_common/test/Makefile
+++ b/bp_common/test/Makefile
@@ -220,7 +220,9 @@ riscvdv_dump: $(foreach x, $(BP_RVDV), $(x).dump)
 	  \"bios\": \"prog.mainram\",\n\
 	  \"load\": \"prog\",\n\
 	  \"memory_base_addr\": 0x80000000,\n\
-	  \"memory_size\": $(MEMSIZE)\n\
+	  \"memory_size\": $(MEMSIZE),\n\
+	  \"mmio_start\": 0x20000,\n\
+	  \"mmio_end\": 0x80000000\n\
 	}" > $(MEM_DIR)/$@.$(MAXINSN).cfg
 	rm $*.*
 

--- a/bp_common/test/Makefile.frag
+++ b/bp_common/test/Makefile.frag
@@ -1,4 +1,5 @@
 BP_DEMOS = \
+  bs                  \
   uc_simple           \
   simple              \
   hello_world         \

--- a/bp_common/test/src/demos/Makefile
+++ b/bp_common/test/src/demos/Makefile
@@ -1,8 +1,8 @@
 
 include Makefile.frag
 
-RISCV_GCC  = riscv64-unknown-elf-gcc --static -nostdlib -nostartfiles -fPIC -march=rv64ia -mabi=lp64 -mcmodel=medany -I$(TEST_DIR)/include
-RISCV_LINK = -static -nostdlib -nostartfiles -L$(TEST_DIR)/lib -T src/riscv.ld 
+RISCV_GCC  = riscv64-unknown-elf-gcc --static -nostartfiles -fPIC -march=rv64ia -mabi=lp64 -mcmodel=medany -I$(TEST_DIR)/include
+RISCV_LINK = -static -nostartfiles -L$(TEST_DIR)/lib -T src/riscv.ld 
 
 .PHONY: all bp-demo-riscv bp-demo-s
 

--- a/bp_common/test/src/demos/Makefile.frag
+++ b/bp_common/test/src/demos/Makefile.frag
@@ -1,4 +1,5 @@
 BP_DEMOS_C = \
+  bs                    \
   basic_demo            \
   atomic_queue_demo_2   \
   atomic_queue_demo_4   \

--- a/bp_common/test/src/demos/src/bs.c
+++ b/bp_common/test/src/demos/src/bs.c
@@ -1,0 +1,263 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <limits.h>
+
+#define N 8
+
+int arr[N];
+uint64_t* putchar_ptr = (uint64_t*)0x00101000;
+uint64_t* finish_ptr  = (uint64_t*)0x00102000;
+
+#define static_assert(cond) switch(0) { case 0: case !!(long)(cond): ; }
+
+#undef putchar
+int putchar(int ch)
+{
+  *putchar_ptr = ch;
+  return 0;
+}
+
+static inline void printnum(void (*putch)(int, void**), void **putdat,
+                    unsigned long long num, unsigned base, int width, int padc)
+{
+  unsigned digs[sizeof(num)*CHAR_BIT];
+  int pos = 0;
+
+  while (1)
+  {
+    digs[pos++] = num % base;
+    if (num < base)
+      break;
+    num /= base;
+  }
+
+  while (width-- > pos)
+    putch(padc, putdat);
+
+  while (pos-- > 0)
+    putch(digs[pos] + (digs[pos] >= 10 ? 'a' - 10 : '0'), putdat);
+}
+
+static unsigned long long getuint(va_list *ap, int lflag)
+{
+  if (lflag >= 2)
+    return va_arg(*ap, unsigned long long);
+  else if (lflag)
+    return va_arg(*ap, unsigned long);
+  else
+    return va_arg(*ap, unsigned int);
+}
+
+static long long getint(va_list *ap, int lflag)
+{
+  if (lflag >= 2)
+    return va_arg(*ap, long long);
+  else if (lflag)
+    return va_arg(*ap, long);
+  else
+    return va_arg(*ap, int);
+}
+
+static void vprintfmt(void (*putch)(int, void**), void **putdat, const char *fmt, va_list ap)
+{
+  register const char* p;
+  const char* last_fmt;
+  register int ch, err;
+  unsigned long long num;
+  int base, lflag, width, precision, altflag;
+  char padc;
+
+  while (1) {
+    while ((ch = *(unsigned char *) fmt) != '%') {
+      if (ch == '\0')
+        return;
+      fmt++;
+      putch(ch, putdat);
+    }
+    fmt++;
+
+    // Process a %-escape sequence
+    last_fmt = fmt;
+    padc = ' ';
+    width = -1;
+    precision = -1;
+    lflag = 0;
+    altflag = 0;
+  reswitch:
+    switch (ch = *(unsigned char *) fmt++) {
+
+    // flag to pad on the right
+    case '-':
+      padc = '-';
+      goto reswitch;
+      
+    // flag to pad with 0's instead of spaces
+    case '0':
+      padc = '0';
+      goto reswitch;
+
+    // width field
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+      for (precision = 0; ; ++fmt) {
+        precision = precision * 10 + ch - '0';
+        ch = *fmt;
+        if (ch < '0' || ch > '9')
+          break;
+      }
+      goto process_precision;
+
+    case '*':
+      precision = va_arg(ap, int);
+      goto process_precision;
+
+    case '.':
+      if (width < 0)
+        width = 0;
+      goto reswitch;
+
+    case '#':
+      altflag = 1;
+      goto reswitch;
+
+    process_precision:
+      if (width < 0)
+        width = precision, precision = -1;
+      goto reswitch;
+
+    // long flag (doubled for long long)
+    case 'l':
+      lflag++;
+      goto reswitch;
+
+    // character
+    case 'c':
+      putch(va_arg(ap, int), putdat);
+      break;
+
+    // string
+    case 's':
+      if ((p = va_arg(ap, char *)) == NULL)
+        p = "(null)";
+      if (width > 0 && padc != '-')
+        for (width -= strnlen(p, precision); width > 0; width--)
+          putch(padc, putdat);
+      for (; (ch = *p) != '\0' && (precision < 0 || --precision >= 0); width--) {
+        putch(ch, putdat);
+        p++;
+      }
+      for (; width > 0; width--)
+        putch(' ', putdat);
+      break;
+
+    // (signed) decimal
+    case 'd':
+      num = getint(&ap, lflag);
+      if ((long long) num < 0) {
+        putch('-', putdat);
+        num = -(long long) num;
+      }
+      base = 10;
+      goto signed_number;
+
+    // unsigned decimal
+    case 'u':
+      base = 10;
+      goto unsigned_number;
+
+    // (unsigned) octal
+    case 'o':
+      // should do something with padding so it's always 3 octits
+      base = 8;
+      goto unsigned_number;
+
+    // pointer
+    case 'p':
+      static_assert(sizeof(long) == sizeof(void*));
+      lflag = 1;
+      putch('0', putdat);
+      putch('x', putdat);
+      /* fall through to 'x' */
+
+    // (unsigned) hexadecimal
+    case 'x':
+      base = 16;
+    unsigned_number:
+      num = getuint(&ap, lflag);
+    signed_number:
+      printnum(putch, putdat, num, base, width, padc);
+      break;
+
+    // escaped '%' character
+    case '%':
+      putch(ch, putdat);
+      break;
+      
+    // unrecognized escape sequence - just print it literally
+    default:
+      putch('%', putdat);
+      fmt = last_fmt;
+      break;
+    }
+  }
+}
+
+int printf(const char* fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+
+  vprintfmt((void*)putchar, 0, fmt, ap);
+
+  va_end(ap);
+  return 0; // incorrect return value, but who cares, anyway?
+}
+
+void printArray(int arr[], int size)  
+{  
+    int i;  
+    for (i = 0; i < size; i++)  
+        printf("%d ", arr[i]);
+    printf("\n"); 
+}
+
+void swap(int *xp, int *yp)  
+{  
+    int temp = *xp;  
+    *xp = *yp;  
+    *yp = temp;  
+}  
+  
+// A function to implement bubble sort  
+void bubbleSort(int arr[], int n)  
+{  
+    int i, j;  
+    for (i = 0; i < n-1; i++) {      
+      printArray(arr, N);
+      // Last i elements are already in place  
+      for (j = 0; j < n-i-1; j++)  
+          if (arr[j] > arr[j+1])  
+              swap(&arr[j], &arr[j+1]);  
+    }
+}
+
+int main(int argc, char** argv) {
+  
+  int i;
+  for(i=0; i<N; i++) {
+    arr[i] = N-i;
+  }
+  bubbleSort(arr, N);
+  printArray(arr, N);
+  *(finish_ptr) = 0;
+  return 0;
+}

--- a/bp_common/test/src/perch/start.S
+++ b/bp_common/test/src/perch/start.S
@@ -5,7 +5,7 @@ _start:
 /* setup stack pointers. Stacks start at 0x8FFF_CFFF */
 /* We then subtract off 8K*coreID. The top 4K is for the core emulation stack
  * the lower 4K is for the program TODO: Maybe larger stack value? */
-    li   sp, 0x8FFFCFF0
+    li   sp, 0x80010000
     csrr x1, mhartid 
     slli x1, x1, 13
     sub  sp, sp, x1

--- a/bp_top/test/common/bp_monitor.cpp
+++ b/bp_top/test/common/bp_monitor.cpp
@@ -20,7 +20,8 @@ void monitor() {
   int c = -1;
   while(1) {
     c = getchar();
-    getchar_queue.push(c);
+    if(c != -1)
+      getchar_queue.push(c);
   }
 }
 

--- a/bp_top/test/common/bp_nonsynth_cosim.v
+++ b/bp_top/test/common/bp_nonsynth_cosim.v
@@ -1,0 +1,75 @@
+
+module bp_nonsynth_cosim
+  import bp_common_pkg::*;
+  import bp_common_aviary_pkg::*;
+  import bp_common_rv64_pkg::*;
+  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
+    `declare_bp_proc_params(bp_params_p)
+    
+    , parameter config_file_p = "inv"
+    )
+   (input                                     clk_i
+    , input                                   reset_i
+    , input                                   freeze_i
+
+    , input [`BSG_SAFE_CLOG2(num_core_p)-1:0] mhartid_i
+
+    , input                                   commit_v_i
+    , input [vaddr_width_p-1:0]               commit_pc_i
+    , input [instr_width_p-1:0]               commit_instr_i
+    , input                                   rd_w_v_i
+    , input [rv64_reg_addr_width_gp-1:0]      rd_addr_i
+    , input [dword_width_p-1:0]               rd_data_i
+    , input                                   interrupt_v_i
+    , input [dword_width_p-1:0]               cause_i
+    );
+
+import "DPI-C" context function void init_dromajo(string cfg_f_name);
+import "DPI-C" context function void dromajo_step(int      hart_id,
+                                                  longint pc,
+                                                  int insn,
+                                                  longint wdata);
+import "DPI-C" context function void dromajo_trap(int hart_id, longint cause);
+
+logic freeze_r;
+always_ff @(posedge clk_i)
+  freeze_r <= freeze_i;
+
+always_ff @(negedge clk_i)
+  if (freeze_r & ~freeze_i)
+    begin
+      init_dromajo(config_file_p);
+    end
+
+  logic                     commit_v_r;
+  logic [vaddr_width_p-1:0] commit_pc_r;
+  logic [instr_width_p-1:0] commit_instr_r;
+  bsg_dff
+   #(.width_p(1+vaddr_width_p+instr_width_p))
+   commit__reg
+    (.clk_i(clk_i)
+     ,.data_i({commit_v_i, commit_pc_i, commit_instr_i})
+     ,.data_o({commit_v_r, commit_pc_r, commit_instr_r})
+     );
+     
+  logic                     interrupt_v_r;
+  logic [dword_width_p-1:0] cause_r;
+  bsg_dff
+   #(.width_p(1+dword_width_p))
+   trap__reg
+    (.clk_i(clk_i)
+     ,.data_i({interrupt_v_i, cause_i})
+     ,.data_o({interrupt_v_r, cause_r})
+     );
+
+  always_ff @(negedge clk_i) begin
+    if(interrupt_v_r) begin
+      dromajo_trap(mhartid_i, cause_r);
+    end
+    else if (commit_v_r & commit_pc_r != '0) begin
+      dromajo_step(mhartid_i, 64'($signed(commit_pc_r)), commit_instr_r, rd_data_i);
+    end
+  end
+
+endmodule
+

--- a/bp_top/test/common/bp_nonsynth_nbf_loader.v
+++ b/bp_top/test/common/bp_nonsynth_nbf_loader.v
@@ -40,6 +40,14 @@ module bp_nonsynth_nbf_loader
   ,output                                  io_resp_ready_o
   );
   
+  enum logic [5:0] {
+    RESET
+    ,BP_RESET_SET
+    ,SEND_NBF
+    ,FREEZE_CLR
+    ,DONE
+  } state_n, state_r;
+  
   // response network not used
   wire unused_resp = &{io_resp_i, io_resp_v_i};
   assign io_resp_ready_o = 1'b1;
@@ -71,10 +79,11 @@ module bp_nonsynth_nbf_loader
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
   bp_cce_mem_msg_s io_cmd, io_resp;
   logic io_cmd_v_lo;
+  logic done_r, done_n;
   
   assign io_cmd_o = io_cmd;
   assign io_resp = io_resp_i;
-  assign io_cmd_v_o = io_cmd_v_lo;
+  assign io_cmd_v_o = ~credits_full_lo & ((state_r == SEND_NBF) | (state_r == FREEZE_CLR));
 
   // read nbf file.
   logic [nbf_width_lp-1:0] nbf [max_nbf_index_lp-1:0];
@@ -85,9 +94,9 @@ module bp_nonsynth_nbf_loader
   // assemble cce cmd packet
   always_comb
   begin
-    io_cmd.data = curr_nbf.data;
+    io_cmd.data = (state_r == FREEZE_CLR) ? dword_width_p'(0) : curr_nbf.data;
     io_cmd.payload = '0;
-    io_cmd.addr = curr_nbf.addr;
+    io_cmd.addr = (state_r == FREEZE_CLR) ? {cfg_dev_gp, cfg_addr_width_p'(bp_cfg_reg_freeze_gp)} : curr_nbf.addr;
     io_cmd.msg_type = e_cce_mem_uc_wr;
     
     case (curr_nbf.opcode)
@@ -100,41 +109,31 @@ module bp_nonsynth_nbf_loader
   // read nbf file
   initial $readmemh(nbf_filename_p, nbf);
 
-  logic done_r, done_n;
-  assign done_o = done_r & credits_empty_lo;
- 
- // combinational
+  assign done_o = (state_r == DONE) & credits_empty_lo;
+  assign nbf_index_n = nbf_index_r + io_cmd_yumi_i;
+   // combinational
   always_comb 
   begin
-    io_cmd_v_lo = 1'b0;
-    nbf_index_n = nbf_index_r;
-    done_n = 1'b0;
-    if (~reset_i) 
-      begin
-        if (curr_nbf.opcode == 8'hFF)
-          begin
-            done_n = 1'b1;
-          end
-        else 
-          begin
-            io_cmd_v_lo = ~credits_full_lo;
-            nbf_index_n = nbf_index_r + io_cmd_yumi_i;
-          end
-      end
+    unique casez (state_r)
+      RESET       : state_n = reset_i ? RESET : SEND_NBF;
+      SEND_NBF    : state_n = (curr_nbf.opcode == 8'hFF) ? FREEZE_CLR : SEND_NBF;
+      FREEZE_CLR  : state_n = io_cmd_yumi_i ? DONE : FREEZE_CLR;
+      DONE        : state_n = DONE;
+      default : state_n = RESET;
+    endcase
   end
-
-  // sequential
+  
   always_ff @(posedge clk_i)
   begin
     if (reset_i)
       begin
         nbf_index_r <= '0;
-        done_r <= 1'b0;
+        state_r <= RESET;
       end
     else 
       begin
         nbf_index_r <= nbf_index_n;
-        done_r <= done_n;
+        state_r <= state_n;
       end
   end
 

--- a/bp_top/test/common/dromajo_cosim.cpp
+++ b/bp_top/test/common/dromajo_cosim.cpp
@@ -17,18 +17,22 @@ extern "C" void init_dromajo(char* cfg_f_name) {
 extern "C" void dromajo_step(int      hart_id,
                              uint64_t pc,
                              uint32_t insn,
-                             uint64_t wdata,
-                             uint64_t mstatus) {
+                             uint64_t wdata) {
   int exit_code = dromajo_cosim_step(dromajo_pointer, 
                                      hart_id,
                                      pc,
                                      insn,
                                      wdata,
                                      0,
-                                     true);
+                                     true,
+                                     false);
 
   if (exit_code != 0) {
     std::cout << "oops!" << std::endl;
-    abort();
+    exit(exit_code);
   }
+}
+
+extern "C" void dromajo_trap(int hart_id, uint64_t cause) {
+  dromajo_cosim_raise_trap(dromajo_pointer, hart_id, cause, false);
 }

--- a/bp_top/test/common/dromajo_cosim.cpp
+++ b/bp_top/test/common/dromajo_cosim.cpp
@@ -1,0 +1,34 @@
+#include "svdpi.h"
+#include <iostream>
+#include "dromajo_cosim.h"
+#include "stdlib.h"
+#include <string>
+
+dromajo_cosim_state_t* dromajo_pointer;
+uint64_t d_address = 0;
+uint64_t d_count = 0;
+
+extern "C" void init_dromajo(char* cfg_f_name) {
+  char *argv[] = {(char*)"Variane", cfg_f_name};
+
+  dromajo_pointer = dromajo_cosim_init(2, argv);
+}
+
+extern "C" void dromajo_step(int      hart_id,
+                             uint64_t pc,
+                             uint32_t insn,
+                             uint64_t wdata,
+                             uint64_t mstatus) {
+  int exit_code = dromajo_cosim_step(dromajo_pointer, 
+                                     hart_id,
+                                     pc,
+                                     insn,
+                                     wdata,
+                                     0,
+                                     true);
+
+  if (exit_code != 0) {
+    std::cout << "oops!" << std::endl;
+    abort();
+  }
+}

--- a/bp_top/test/tb/bp_top_trace_demo/Makefile.frag
+++ b/bp_top/test/tb/bp_top_trace_demo/Makefile.frag
@@ -7,6 +7,7 @@ NPC_TRACE_P    ?= 0
 VM_TRACE_P     ?= 0
 PRELOAD_MEM_P  ?= 1
 LOAD_NBF_P     ?= 0
+COSIM_P        ?= 0
 
 export DUT_PARAMS = 
 
@@ -18,7 +19,8 @@ export TB_PARAMS  = -pvalue+calc_trace_p=$(CALC_TRACE_P) \
                     -pvalue+npc_trace_p=$(NPC_TRACE_P) \
                     -pvalue+vm_trace_p=$(VM_TRACE_P) \
                     -pvalue+preload_mem_p=$(PRELOAD_MEM_P) \
-                    -pvalue+load_nbf_p=$(LOAD_NBF_P)
+                    -pvalue+load_nbf_p=$(LOAD_NBF_P) \
+                    -pvalue+cosim_p=$(COSIM_P)
 
 HDL_PARAMS  = $(DUT_PARAMS) $(TB_PARAMS)
 

--- a/bp_top/test/tb/bp_top_trace_demo/Makefile.frag
+++ b/bp_top/test/tb/bp_top_trace_demo/Makefile.frag
@@ -5,7 +5,8 @@ DRAM_TRACE_P   ?= 0
 DCACHE_TRACE_P ?= 0
 NPC_TRACE_P    ?= 0
 VM_TRACE_P     ?= 0
-PRELOAD_MEM_P  ?= 0
+PRELOAD_MEM_P  ?= 1
+LOAD_NBF_P     ?= 0
 
 export DUT_PARAMS = 
 
@@ -13,10 +14,11 @@ export TB_PARAMS  = -pvalue+calc_trace_p=$(CALC_TRACE_P) \
                     -pvalue+cce_trace_p=$(CCE_TRACE_P)   \
                     -pvalue+cmt_trace_p=$(CMT_TRACE_P)   \
                     -pvalue+dram_trace_p=$(DRAM_TRACE_P) \
-					-pvalue+dcache_trace_p=$(DCACHE_TRACE_P) \
+                    -pvalue+dcache_trace_p=$(DCACHE_TRACE_P) \
                     -pvalue+npc_trace_p=$(NPC_TRACE_P) \
                     -pvalue+vm_trace_p=$(VM_TRACE_P) \
-					-pvalue+preload_mem_p=$(PRELOAD_MEM_P)
+                    -pvalue+preload_mem_p=$(PRELOAD_MEM_P) \
+                    -pvalue+load_nbf_p=$(LOAD_NBF_P)
 
 HDL_PARAMS  = $(DUT_PARAMS) $(TB_PARAMS)
 

--- a/bp_top/test/tb/bp_top_trace_demo/flist.vcs
+++ b/bp_top/test/tb/bp_top_trace_demo/flist.vcs
@@ -23,5 +23,6 @@ $BP_TOP_DIR/test/common/bp_nonsynth_host.v
 $BP_TOP_DIR/test/common/bp_nonsynth_if_verif.v
 $BP_TOP_DIR/test/common/bp_nonsynth_commit_tracer.v
 $BP_TOP_DIR/test/common/bp_nonsynth_nbf_loader.v
+$BP_TOP_DIR/test/common/bp_nonsynth_cosim.v
 $BP_TOP_DIR/test/common/bp_monitor.cpp
 $BP_TOP_DIR/test/common/dromajo_cosim.cpp

--- a/bp_top/test/tb/bp_top_trace_demo/flist.vcs
+++ b/bp_top/test/tb/bp_top_trace_demo/flist.vcs
@@ -24,3 +24,4 @@ $BP_TOP_DIR/test/common/bp_nonsynth_if_verif.v
 $BP_TOP_DIR/test/common/bp_nonsynth_commit_tracer.v
 $BP_TOP_DIR/test/common/bp_nonsynth_nbf_loader.v
 $BP_TOP_DIR/test/common/bp_monitor.cpp
+$BP_TOP_DIR/test/common/dromajo_cosim.cpp

--- a/bp_top/test/tb/bp_top_trace_demo/testbench.v
+++ b/bp_top/test/tb/bp_top_trace_demo/testbench.v
@@ -145,29 +145,28 @@ wrapper
        ,.rd_data_i(be_calculator.wb_pkt.rd_data)
        );
 
-  if(cosim_p)
-    bind bp_be_top
-      bp_nonsynth_cosim
-       #(.bp_params_p(bp_params_p)
-         ,.config_file_p("prog.cfg"))
-        cosim
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
-         ,.freeze_i(be_checker.scheduler.int_regfile.cfg_bus.freeze)
+  bind bp_be_top
+    bp_nonsynth_cosim
+     #(.bp_params_p(bp_params_p)
+       ,.config_file_p("prog.cfg"))
+      cosim
+      (.clk_i(clk_i & (testbench.cosim_p == 1))
+       ,.reset_i(reset_i)
+       ,.freeze_i(be_checker.scheduler.int_regfile.cfg_bus.freeze)
 
-         ,.mhartid_i(be_checker.scheduler.int_regfile.cfg_bus.core_id)
+       ,.mhartid_i(be_checker.scheduler.int_regfile.cfg_bus.core_id)
 
-         ,.commit_v_i(be_calculator.commit_pkt.instret)
-         ,.commit_pc_i(be_calculator.commit_pkt.pc)
-         ,.commit_instr_i(be_calculator.commit_pkt.instr)
+       ,.commit_v_i(be_calculator.commit_pkt.instret)
+       ,.commit_pc_i(be_calculator.commit_pkt.pc)
+       ,.commit_instr_i(be_calculator.commit_pkt.instr)
 
-         ,.rd_w_v_i(be_calculator.wb_pkt.rd_w_v)
-         ,.rd_addr_i(be_calculator.wb_pkt.rd_addr)
-         ,.rd_data_i(be_calculator.wb_pkt.rd_data)
+       ,.rd_w_v_i(be_calculator.wb_pkt.rd_w_v)
+       ,.rd_addr_i(be_calculator.wb_pkt.rd_addr)
+       ,.rd_data_i(be_calculator.wb_pkt.rd_data)
 
-         ,.interrupt_v_i(be_mem.csr.trap_pkt_cast_o._interrupt)
-         ,.cause_i(be_mem.csr.trap_pkt_cast_o.cause)
-         );
+       ,.interrupt_v_i(be_mem.csr.trap_pkt_cast_o._interrupt)
+       ,.cause_i(be_mem.csr.trap_pkt_cast_o.cause)
+       );
 
   bind bp_be_director
     bp_be_nonsynth_npc_tracer

--- a/bp_top/test/tb/bp_top_trace_demo/testbench.v
+++ b/bp_top/test/tb/bp_top_trace_demo/testbench.v
@@ -467,7 +467,7 @@ bp_cce_mmio_cfg_loader
     ,.inst_ram_addr_width_p(cce_instr_ram_addr_width_lp)
     ,.inst_ram_els_p(num_cce_instr_ram_els_p)
     ,.skip_ram_init_p(skip_init_p)
-    ,.clear_freeze_p(~load_nbf_p)
+    ,.clear_freeze_p(!load_nbf_p)
     )
   cfg_loader
   (.clk_i(clk_i)

--- a/bp_top/test/tb/bp_top_trace_demo/testbench.v
+++ b/bp_top/test/tb/bp_top_trace_demo/testbench.v
@@ -30,6 +30,7 @@ module testbench
    , parameter preload_mem_p               = 0
    , parameter load_nbf_p                  = 0
    , parameter skip_init_p                 = 0
+   , parameter cosim_p                     = 0
 
    , parameter mem_zero_p         = 1
    , parameter mem_file_p         = "prog.mem"
@@ -143,6 +144,30 @@ wrapper
        ,.rd_addr_i(be_calculator.wb_pkt.rd_addr)
        ,.rd_data_i(be_calculator.wb_pkt.rd_data)
        );
+
+  if(cosim_p)
+    bind bp_be_top
+      bp_nonsynth_cosim
+       #(.bp_params_p(bp_params_p)
+         ,.config_file_p("prog.cfg"))
+        cosim
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+         ,.freeze_i(be_checker.scheduler.int_regfile.cfg_bus.freeze)
+
+         ,.mhartid_i(be_checker.scheduler.int_regfile.cfg_bus.core_id)
+
+         ,.commit_v_i(be_calculator.commit_pkt.instret)
+         ,.commit_pc_i(be_calculator.commit_pkt.pc)
+         ,.commit_instr_i(be_calculator.commit_pkt.instr)
+
+         ,.rd_w_v_i(be_calculator.wb_pkt.rd_w_v)
+         ,.rd_addr_i(be_calculator.wb_pkt.rd_addr)
+         ,.rd_data_i(be_calculator.wb_pkt.rd_data)
+
+         ,.interrupt_v_i(be_mem.csr.trap_pkt_cast_o._interrupt)
+         ,.cause_i(be_mem.csr.trap_pkt_cast_o.cause)
+         );
 
   bind bp_be_director
     bp_be_nonsynth_npc_tracer

--- a/bp_top/test/tb/bp_top_trace_demo/testbench.v
+++ b/bp_top/test/tb/bp_top_trace_demo/testbench.v
@@ -31,6 +31,8 @@ module testbench
    , parameter load_nbf_p                  = 0
    , parameter skip_init_p                 = 0
    , parameter cosim_p                     = 0
+   , parameter cosim_cfg_file_p            = "prog.cfg"
+   , parameter elf_file_p                  = "prog.elf"
 
    , parameter mem_zero_p         = 1
    , parameter mem_file_p         = "prog.mem"
@@ -148,7 +150,9 @@ wrapper
   bind bp_be_top
     bp_nonsynth_cosim
      #(.bp_params_p(bp_params_p)
-       ,.config_file_p("prog.cfg"))
+       ,.config_file_p(testbench.load_nbf_p
+                       ? testbench.cosim_cfg_file_p
+                       : testbench.elf_file_p))
       cosim
       (.clk_i(clk_i & (testbench.cosim_p == 1))
        ,.reset_i(reset_i)

--- a/external/Makefile.tools
+++ b/external/Makefile.tools
@@ -51,6 +51,8 @@ dromajo:
 	@cd $(TOP); git submodule update --init --recursive $(DROMAJO_DIR)
 	$(MAKE) -C $(DROMAJO_DIR)/src
 	cp $(DROMAJO_DIR)/src/dromajo $(BP_EXTERNAL_DIR)/bin
+	cp $(DROMAJO_DIR)/src/libdromajo_cosim.a $(LIB_DIR)
+	cp $(DROMAJO_DIR)/src/dromajo_cosim.h $(INCLUDE_DIR)
 
 axe: 
 	@cd $(TOP); git submodule update --init --recursive $(AXE_DIR)


### PR DESCRIPTION
This PR adds the capability to run a benchmark on Dromajo(as an ISA simulator) until for a certain number of instructions and then resume with cosimulation in RTL.

To run on Dromajo and generate the checkpoint files run:
`cd bp_common/test`
`make <test>.dromajo MAXINSN=<n> MEMSIZE=<k in MB>`
This generates test files under the name `<test>.dromajo.<n>`

And then to load the state in RTL and run with cosim enabled run:
`cd bp_top/syn`
`make build.v sim.v PROG=<test>.dromajo.<n> PRELOAD_MEM_P=1 LOAD_NBF_P=1 COSIM_P=1`
This command preloads the mainram with the generated binary, and restores the processor state through the generated nbf files.